### PR TITLE
Make scripts compatible with python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Android Emulator Container Scripts
 
 This is a set of minimal scripts to run the emulator in a container for various
-systems such as Docker, for external consumption.
+systems such as Docker, for external consumption. The scripts are compatible with
+both Python version 2 and 3.
 
 # Install
 

--- a/emu_docker.py
+++ b/emu_docker.py
@@ -34,39 +34,39 @@ def mkdir_p(path):
             raise
 
 if len(sys.argv) < 4:
-    print "Invalid usage. Usage: python emu_docker.py <public-emu-url> <public-sysimg-url> <docker-repo-name> [docker-src-dir (cwd by default]"
+    print("Invalid usage. Usage: python emu_docker.py <public-emu-zip> <public-sysimg-zip> <docker-repo-name> [docker-src-dir (cwd by default]")
     sys.exit(1)
 
 src_dir = os.path.join(os.getcwd(), "src")
 
-print sys.argv
+print(sys.argv)
 
 emu_zip, sysimg_zip, repo_name = sys.argv[1:5]
 
 if len(sys.argv) > 4:
     src_dir = sys.argv[4]
 
-print "Emulator zip: %s" % emu_zip
-print "Sysimg zip: %s" % sysimg_zip
-print "Repo name: %s" % repo_name
+print("Emulator zip: %s" % emu_zip)
+print("Sysimg zip: %s" % sysimg_zip)
+print("Repo name: %s" % repo_name)
 
-print "Docker src dir: %s" % src_dir
+print("Docker src dir: %s" % src_dir)
 
 mkdir_p(src_dir)
 
-print "Copying zips to docker src dir..."
+print("Copying zips to docker src dir...")
 shutil.copy2(emu_zip, src_dir)
 shutil.copy2(sysimg_zip, src_dir)
-print "Done copying"
+print("Done copying")
 
 platform_tools_dir = os.path.join(src_dir, "platform-tools")
 avd_dir_out_path = os.path.join(src_dir, "avd")
 avd_dir_avd_out_path = os.path.join(src_dir, "avd", "Pixel2.avd")
 
-print "Platform tools dir: %s" % platform_tools_dir
-print "AVD dir: %s" % avd_dir_avd_out_path
+print("Platform tools dir: %s" % platform_tools_dir)
+print("AVD dir: %s" % avd_dir_avd_out_path)
 
-print "Creating dirs..."
+print("Creating dirs...")
 
 mkdir_p(platform_tools_dir)
 mkdir_p(avd_dir_out_path)
@@ -74,14 +74,14 @@ mkdir_p(avd_dir_avd_out_path)
 
 adb_loc = find_executable("adb")
 
-print "Using adb: %s" % adb_loc
+print("Using adb: %s" % adb_loc)
 
 shutil.copy2(adb_loc, platform_tools_dir)
 
 avd_root_ini_out_path = os.path.join(avd_dir_out_path, "Pixel2.ini")
 avd_config_ini_out_path = os.path.join(avd_dir_avd_out_path, "config.ini")
 
-print "Writing config.ini and AVD info"
+print("Writing config.ini and AVD info")
 
 fh = open(avd_root_ini_out_path, 'w')
 fh.write(emu_templates.avd_root_ini_template)
@@ -91,21 +91,21 @@ fh = open(avd_config_ini_out_path, 'w')
 fh.write(emu_templates.avd_config_ini_template)
 fh.close()
 
-print "Writing launch-emulator.sh"
+print("Writing launch-emulator.sh")
 
 launch_emulator_out_path = os.path.join(src_dir, "launch-emulator.sh")
 fh = open(launch_emulator_out_path, 'w')
 fh.write(emu_templates.launch_emulator_sh_template)
 fh.close()
 
-print "Writing default.pa"
+print("Writing default.pa")
 
 default_pa_out_path = os.path.join(src_dir, "default.pa")
 fh = open(default_pa_out_path, 'w')
 fh.write(emu_templates.default_pa_template)
 fh.close()
 
-print "Writing Dockerfile"
+print("Writing Dockerfile")
 
 dockerfile_out_path = os.path.join(src_dir, "Dockerfile")
 
@@ -123,4 +123,4 @@ with open(dockerfile_out_path, 'w') as dfile:
             sysimg_zip=sysimg_zip,
             date="TEST_DATE"))
 
-print "Done setting up Dockerfile"
+print("Done setting up Dockerfile")

--- a/emu_downloads_menu.py
+++ b/emu_downloads_menu.py
@@ -115,7 +115,7 @@ def get_images_info():
     # Flatten the list of lists into a system image objects.
     infos = [SysImgInfo(item) for sublist in xml for item in sublist]
     # Filter only for x86_64 images (TODO: allow other types)
-    x64_images = filter(lambda info: info.abi == "x86_64", infos)
+    x64_images = [info for info in infos if info.abi == "x86_64"]
     return x64_images
 
 def get_emus_info():
@@ -128,8 +128,7 @@ def get_emus_info():
         response = urlfetch.get(url)
         if response.status == 200:
             xml.append(response.content)
-    xml = [filter(lambda p: "emulator" == p.attrib["path"], \
-                  ET.fromstring(x).findall('remotePackage')) for x in xml]
+    xml = [[p for p in ET.fromstring(x).findall('remotePackage') if "emulator" == p.attrib["path"]] for x in xml]
     # Flatten the list of lists into a system image objects.
     infos = [EmuInfo(item) for sublist in xml for item in sublist]
     return infos
@@ -138,8 +137,8 @@ img_infos = get_images_info()
 emu_infos = get_emus_info()
 
 for img_info in img_infos:
-    print "SYSIMG", img_info.tag, img_info.api, img_info.letter, img_info.abi, img_info.url
+    print("SYSIMG {} {} {} {} {}".format(img_info.tag, img_info.api, img_info.letter, img_info.abi, img_info.url))
 
 for emu_info in emu_infos:
-    for (hostos, url) in emu_info.urls.items():
-        print "EMU", emu_info.channel, emu_info.version, hostos, url
+    for (hostos, url) in list(emu_info.urls.items()):
+        print("EMU {} {} {} {}".format(emu_info.channel, emu_info.version, hostos, url))


### PR DESCRIPTION
- Transformation done by 2to3 -w *.py
- Includes change of messaging so people doen't pass in a url vs
  zipfile.

Test: Both python2 and python3 runs succeed.