### PR TITLE
Update documentation and cleanup after left overs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Files used by our scripts
+*.zip
+src/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "venv/bin/python2.7"
+}

--- a/README.md
+++ b/README.md
@@ -1,22 +1,44 @@
 # Android Emulator Container Scripts
 
 This is a set of minimal scripts to run the emulator in a container for various
-systems such as Docker, for external consumption. The scripts are compatible with
-both Python version 2 and 3.
+systems such as Docker, for external consumption. The scripts are compatible
+with both Python version 2 and 3.
+
+The container scripts can currently launch *[Android
+OREO](https://developer.android.com/about/versions/oreo)* and later versions.
+
+*Note that this is still an experimental feature!*
 
 # Requirements
 
-These demos are intended to be run on a linux OS. Your system must meet the following requirements:
+These demos are intended to be run on a linux OS. Your system must meet the
+following requirements:
 
 - A Python interpreter must be installed.
-- ADB must be available on the path. ADB comes as part of the [Android SDK](http://www.androiddocs.com/sdk/installing/index.html). Note that installing the command line tools is sufficient.
+- ADB must be available on the path. ADB comes as part of the [Android
+  SDK](http://www.androiddocs.com/sdk/installing/index.html). Note that
+  installing the command line tools is sufficient.
 - [Docker](https://docs.docker.com/v17.12/install/) must be installed.
 - [Docker-compose](https://docs.docker.com/compose/install/) must be installed.
-- KVM must be available. You can get access to KVM by running on "bare metal", or on a (virtual) machine that provides [nested virtualization](https://blog.turbonomic.com/blog/). If you are planning to run this in the cloud (gce/azure/aws/etc..) you first must make sure you have access to KVM. Details on how to get access to KVM on the various cloud providers can be found here:
+- KVM must be available. You can get access to KVM by running on "bare metal",
+  or on a (virtual) machine that provides [nested
+  virtualization](https://blog.turbonomic.com/blog/). If you are planning to run
+  this in the cloud (gce/azure/aws/etc..) you first must make sure you have
+  access to KVM. Details on how to get access to KVM on the various cloud
+  providers can be found here:
 
-    - AWS provides [bare metal](https://aws.amazon.com/about-aws/whats-new/2019/02/introducing-five-new-amazon-ec2-bare-metal-instances/) instances that provide access to KVM.
-    - Azure: Follow these [instructions](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/nested-virtualization) to enable nested virtualization.
-    - GCE: Follow these [instructions](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances) to enable nested virtualization.
+    - AWS provides [bare
+      metal](https://aws.amazon.com/about-aws/whats-new/2019/02/introducing-five-new-amazon-ec2-bare-metal-instances/)
+      instances that provide access to KVM.
+    - Azure: Follow these
+      [instructions](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/nested-virtualization)
+      to enable nested virtualization.
+    - GCE: Follow these
+      [instructions](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances)
+      to enable nested virtualization.
+
+Keep in mind that you will see reduced performance if you are making use of
+nested virtualization.
 
 
 # Install
@@ -25,19 +47,22 @@ You can install the python package as follows:
 
     python setup.py install --user
 
-This should make the  executable `emu-docker` available. You can get detailed information about the usage by launching it as follows:
+This should make the  executable `emu-docker` available. You can get detailed
+information about the usage by launching it as follows:
 
     emu-docker -h
 
 ## Quick start, interactively creating a docker image
 
-You can interactively select which version of android and emulator you wish to use by running:
+You can interactively select which version of android and emulator you wish to
+use by running:
 
     emu-docker interactive
 
-You will be asked to select a system image and an emulator version, after which a docker file will be created.
-The system image and emulator will be downloaded to the current directory if needed. If you wish to interact with
-the emulator in the browser you will need to use a canary build!
+You will be asked to select a system image and an emulator version, after which
+a docker file will be created. The system image and emulator will be downloaded
+to the current directory if needed. If you wish to interact with the emulator in
+the browser you will need to use a canary build!
 
 You can now create the docker image by running:
 
@@ -53,7 +78,8 @@ Issuing:
 
     emu-docker list
 
-will query the currently published Android SDK and output URLs for the zip files of:
+will query the currently published Android SDK and output URLs for the zip files
+of:
 
 - Available and currently Docker-compatible system images
 - Currently published and advertised emulator binaries
@@ -95,11 +121,11 @@ One can then use tools like `wget` or a browser to download a desired emulator
 and system image.  After the two are obtained, we can build a Docker image.
 
 
-Given an emulator zip file and a system image zip file, we can build a
-directory that can be sent to `docker build` via the following invocation of
-`emu_docker`:
+Given an emulator zip file and a system image zip file, we can build a directory
+that can be sent to `docker build` via the following invocation of `emu_docker`:
 
-     emu_docker create <emulator-zip> <system-image-zip>  [--dest docker-src-dir (getcwd()/src by default)]
+     emu_docker create <emulator-zip> <system-image-zip>  [--dest docker-src-dir
+     (getcwd()/src by default)]
 
 This places all the right elements to run a docker image, but does not build,
 run or publish yet. A Linux emulator zip file must be used.
@@ -108,7 +134,8 @@ run or publish yet. A Linux emulator zip file must be used.
 
 To build the Docker image corresponding to these emulators and system images:
 
-    docker build <docker-src-dir, either ./src or specified argument to emu_docker.py>
+    docker build <docker-src-dir, either ./src or specified argument to
+    emu_docker.py>
 
 A Docker image ID will output; save this image ID.
 
@@ -123,22 +150,35 @@ We provide the following run script:
 
 It does the following:
 
-    docker run -e "ADBKEY=$(cat ~/.android/adbkey)" --privileged  --publish 5556:5556/tcp --publish 5555:5555/tcp <docker-image-id>
+    docker run -e "ADBKEY=$(cat ~/.android/adbkey)" --privileged  --publish
+    5556:5556/tcp --publish 5555:5555/tcp <docker-image-id>
 
 
 - Sets up the ADB key, assuming one exists at ~/.android/adbkey
 - Uses `--privileged` to have CPU acceleration
-- Starts the emulator in the docker image with its gRPC service, forwarding the host ports 5556/5554 to container ports 5554/5554 respectively.
-- The gRPC service is used to communicate with the running emulator inside the container.
+- Starts the emulator in the docker image with its gRPC service, forwarding the
+  host ports 5556/6555 to container ports 5556/5555 respectively.
+- The gRPC service is used to communicate with the running emulator inside the
+  container.
 
 ## Communicating with the emulator in the container
 
 ## adb
 
 We forward the port 5555 for adb access to the emulator running inside the
-container (TODO: make this configurable per container).
+container (TODO: make this configurable per container). Adb should automatically
+detect the devices:
 
-To enable ADB access, run the following adb command, assuming no other emulators/devices connected:
+
+```sh $ adb devices
+
+List of devices attached:
+emulator-5554   device
+```
+
+
+If it does not, run the following adb command, assuming no other
+emulators/devices are connected:
 
     adb connect localhost:5555
 
@@ -148,39 +188,47 @@ This repository also contains an example that demonstrates how you can use
 docker to make the emulator accessible through the web. This is done by
 composing the following set of docker containers:
 
-- [Envoy](https://www.envoyproxy.io/), an edge and service proxy: The proxy is responsible for the following:
+- [Envoy](https://www.envoyproxy.io/), an edge and service proxy: The proxy is
+  responsible for the following:
     - Offer TLS (https) using a self signed certificate
     - Redirect traffic on port 80 (http) to port 443 (https)
-    - Act as a [gRPC proxy](https://grpc.io/blog/state-of-grpc-web/) for the emulator.
-    - Redirect other requests to the Nginx component which hosts a [React](https://reactjs.org/) application.
+    - Act as a [gRPC proxy](https://grpc.io/blog/state-of-grpc-web/) for the
+      emulator.
+    - Redirect other requests to the Nginx component which hosts
+      a [React](https://reactjs.org/) application.
 - [Nginx](https://www.nginx.com/), a webserver hosting a compiled React App
 - The emulator with a gRPC endpoint and a WebRTC video bridge.
 
 ## Important Notice!
 
-In order to run this sample and be able to interact with the emulator you must keep the following in mind:
+In order to run this sample and be able to interact with the emulator you must
+keep the following in mind:
 
 - The demo has two methods to display the emulator.
-    1. Create an image every second, which is displayed in the browser. This approach will always work, but gives poor performance.
+    1. Create an image every second, which is displayed in the browser. This
+    approach will always work, but gives poor performance.
     2. Use [WebRTC](https://webrtc.org/) to display the state of the emulator in
-       real time. This will only work if you are able to create a peer to peer connection
-       to the server hosting the emulator. This is usually not a problem when your server
-       is publicly visible, or if you are running the emulator on your own intranet.
+       real time. This will only work if you are able to create a peer to peer
+       connection to the server hosting the emulator. This is usually not
+       a problem when your server is publicly visible, or if you are running the
+       emulator on your own intranet.
 
-- **There is no Authorization/Authentication:.** Anyone who can reach the website will be able to
-  interact with the emulator. Which means they can control the emulator and run arbitrary code
-  inside your emulator.
+- **There is no Authorization/Authentication:.** Anyone who can reach the
+  website will be able to interact with the emulator. Which means they can
+  control the emulator and run arbitrary code inside your emulator.
 
 ## Requirements
 
 - You will need [docker-compose](https://docs.docker.com/compose/install/).
 - You must have port 80 and 443 available. The docker containers will create an
   internal network and expose the http and https ports.
-- You will need to create an emulator docker image, as described in the documentation above.
+- You will need to create an emulator docker image, as described in the
+  documentation above.
 
 ## Running the emulator on the web
 
-Once you have taken care of the steps above you can create the containers as follows:
+Once you have taken care of the steps above you can create the containers as
+follows:
 
     docker-compose -f js/docker/docker-compose.yaml build
 
@@ -194,64 +242,9 @@ cert you should see the emulator in action
 
 ### Troubleshooting
 
-Here are a list of things that we have seen with potential workarounds:
-
-- **I am not seeing any video in the demo* when selecting webrtc*
-
-  1. Click the png button. This will not use webrtc but request individual
-     screenshots from the emulator. If this works you learn the following:
-
-     - The emulator is running.
-     - The gRPC endpoint is properly working.
-
-      If the button does not show the emulator then you are possibly running
-      an older emulator without gRPC support. Make sure you use the latest canary
-      build.
-
-  2. I do see video when using the png button.
-
-     - Click the `webrtc` button. Make sure no video is showing.
-     - Check the JavaScript console log.
-
-     If you only see: `handleJsepMessage: {"start":{}}` then the
-     video bridge is not running as expected. You could consult the logs for
-     more info:  `docker logs docker_emulator_1 | egrep "pulse:|video:"`
-
-    If you see something along the lines of:
-
-     ```javascript
-     handleJsepMessage: {"start":{}}
-     jsep_protocol_driver.js:124 handleJsepMessage: {"sdp":"i...
-     label:emulator_video_stream\r\n","type":"offer"}
-     jsep_protocol_driver.js:76 handlePeerConnectionTrack: connecting [object
-     RTCTrackEvent]
-     webrtc_view.js:42 Connecting video stream: [object HTMLVideoElement]:0
-     jsep_protocol_driver.js:124 handleJsepMessage:
-     {"candidate":"candidate:3808623835 1 udp 2122260223 172.20.0.4 38033 typ
-     host generation 0 ufrag kyFW network-id 1","sdpMLineIndex":0,"sdpMid":"0"}
-     jsep_protocol_driver.js:124 handleJsepMessage:
-     {"candidate":"candidate:2325047 1 udp 1686052607 104.132.0.73 59912 typ
-     srflx raddr 172.20.0.4 rport 38033 generation 0 ufrag kyFW network-id
-     1","sdpMLineIndex":0,"sdpMid":"0"}
-     webrtc_view.js:50 Automatic playback started!
-     ```
-
-     You could be in a situation where
-     a [TURN](https://en.wikipedia.org/wiki/Traversal_Using_Relays_around_NAT)
-     is needed. This is usually only the case when you are in a restricted
-     network. You can launch the emulator `$ANDROID_SDK_ROOT/emulator/emulator
-     -help-turncfg` under linux to learn how to configure turn.
-     You can pass use `emu_docker create --help` to learn how to pass the
-     `--turncfg` flag to the emulator.
-
-
-- **Credential errors when using docker-compose from virtual within a virtual
-  environment:**
-
-  The easiest solution is not to use docker-compose from a virtual environment.
-
+We have a seperate [document](TROUBLESHOOTING.md) related to dealing with
+issues.
 
 ### Modifying the demo
 
-Details on how to modify can React application can be found [here](js/README.md)
-
+Details on how to modify the React application can be found [here](js/README.md)

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,74 @@
+# Known Issues
+
+Here are a list of things that we have seen with potential workarounds:
+
+## Why can't a use an image before O?
+
+Releases before O are using an older linux kernel (3.10). This version of the
+linux kernel has some issues that are under [active
+investigation](https://issuetracker.google.com/issues/140881613).
+
+## The container suddenly stopped and I cannot restart it.
+
+It is possible that the emulator crashes or terminates unexpectedly. In this
+case it is possible that the container gets into a corrupted state.
+
+If this is the case you will have to delete the container:
+
+```sh # stop the container docker stop CONTAINER_ID # removes the container
+docker rm -f  CONTAINER_ID ```
+
+## I am not seeing any video in the demo when selecting webrtc
+
+1. Click the png button. This will not use webrtc but request individual
+   screenshots from the emulator. If this works you learn the following:
+
+    - The emulator is running.
+    - The gRPC endpoint is properly working.
+
+    If the button does not show the emulator then you are possibly running an
+    older emulator without gRPC support. Make sure you use the latest canary
+    build.
+
+2. I do see video when using the png button.
+
+    - Click the `webrtc` button. Make sure no video is showing.
+    - Check the JavaScript console log.
+
+    If you only see: `handleJsepMessage: {"start":{}}` then the video bridge is
+    not running as expected. You could consult the logs for more info:  `docker
+    logs docker_emulator_1 | egrep "pulse:|video:|version:"`
+
+If you see something along the lines of:
+
+    ```javascript
+    handleJsepMessage: {"start":{}}
+    jsep_protocol_driver.js:124 handleJsepMessage: {"sdp":"i...
+    label:emulator_video_stream\r\n","type":"offer"}
+    jsep_protocol_driver.js:76 handlePeerConnectionTrack: connecting [object
+    RTCTrackEvent]
+    webrtc_view.js:42 Connecting video stream: [object HTMLVideoElement]:0
+    jsep_protocol_driver.js:124 handleJsepMessage:
+    {"candidate":"candidate:3808623835 1 udp 2122260223 172.20.0.4 38033 typ
+    host generation 0 ufrag kyFW network-id 1","sdpMLineIndex":0,"sdpMid":"0"}
+    jsep_protocol_driver.js:124 handleJsepMessage:
+    {"candidate":"candidate:2325047 1 udp 1686052607 104.132.0.73 59912 typ
+    srflx raddr 172.20.0.4 rport 38033 generation 0 ufrag kyFW network-id
+    1","sdpMLineIndex":0,"sdpMid":"0"}
+    webrtc_view.js:50 Automatic playback started!
+    ```
+
+    You could be in a situation where
+    a [TURN](https://en.wikipedia.org/wiki/Traversal_Using_Relays_around_NAT) is
+    needed. This is usually only the case when you are in a restricted network.
+    You can launch the emulator `$ANDROID_SDK_ROOT/emulator/emulator
+    -help-turncfg` under linux to learn how to configure turn.  You can pass use
+    `emu_docker create --help` to learn how to pass the `--turncfg` flag to the
+    emulator.
+
+
+## Credential errors with docker-compose
+
+We have seen errors when running docker-compose from a virtual environment.
+
+The easiest solution is not to use docker-compose from a virtual environment.

--- a/configure.sh
+++ b/configure.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Copyright 2019 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+if [ "${BASH_SOURCE-}" = "$0" ]; then
+    echo "You must source this script: \$ source $0" >&2
+    echo "It will create a virtual environment in which emu-docker will be installed."
+    exit 33
+fi
+
+if [ ! -f "./venv/bin/activate" ]; then
+  which virtualenv || { echo "This script relies on virtualenv, you can install it with 'pip install virtualenv' (https://virtualenv.pypa.io)"; return ; }
+  virtualenv venv
+fi
+
+source ./venv/bin/activate
+python setup.py develop
+
+echo "Ready to run emu-docker!"

--- a/emu/emu_docker.py
+++ b/emu/emu_docker.py
@@ -46,6 +46,7 @@ def create_docker(src_dir, emu_zip, sysimg_zip, repo_name='unused', extra=''):
     logging.info("Repo name: %s" % repo_name)
     logging.info("Docker src dir: %s" % src_dir)
 
+    shutil.rmtree(src_dir)
     mkdir_p(src_dir)
 
     print("Copying zips to docker src dir: {}".format(src_dir))
@@ -116,9 +117,9 @@ def create_docker(src_dir, emu_zip, sysimg_zip, repo_name='unused', extra=''):
                 tag="IMAGE_TEST_TAG",
                 api="TEST_API",
                 abi="TEST_ABI",
-                emu_zip=emu_zip,
+                emu_zip=os.path.basename(emu_zip), # Fully qualified name will confuse docker.
                 emu_build_id="TEST_BUILD_ID",
-                sysimg_zip=sysimg_zip,
+                sysimg_zip=os.path.basename(sysimg_zip),
                 date="TEST_DATE"))
 
     print("Created a Dockerfile in {}".format(src_dir))

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ setup(
     # Similar to `install_requires` above, these must be valid existing
     # projects.
     extras_require={  # Optional
-        'dev': ['check-manifest'],
+        'dev': ['check-manifest', 'versioneer'],
         'test': ['coverage'],
     },
 


### PR DESCRIPTION
An unexpected emulator termination can leave the container in a confused state. This can cause subsequent startup failures.

Updates the documentation to explain that we cannot launch images before Oreo.