### PR TITLE
Use /dev/kvm vs requesting privileged access.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,12 +150,12 @@ We provide the following run script:
 
 It does the following:
 
-    docker run -e "ADBKEY=$(cat ~/.android/adbkey)" --privileged  --publish
+    docker run -e "ADBKEY=$(cat ~/.android/adbkey)" --device /dev/kvm--publish
     5556:5556/tcp --publish 5555:5555/tcp <docker-image-id>
 
 
 - Sets up the ADB key, assuming one exists at ~/.android/adbkey
-- Uses `--privileged` to have CPU acceleration
+- Uses `--device /dev/kvm to have CPU acceleration
 - Starts the emulator in the docker image with its gRPC service, forwarding the
   host ports 5556/6555 to container ports 5556/5555 respectively.
 - The gRPC service is used to communicate with the running emulator inside the

--- a/js/docker/docker-compose.yaml
+++ b/js/docker/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       envoymesh:
         aliases:
           - emulator
-    privileged: true
+    devices: /dev/kvm
     shm_size: 128M
     expose:
       - "5556"


### PR DESCRIPTION
We now specifically request access to the devices v.s. requesting
blanket access to everything.

Resolves #16