### PR TITLE
Updated services.emulator.devices field to be an array

### DIFF
--- a/js/docker/docker-compose.yaml
+++ b/js/docker/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       envoymesh:
         aliases:
           - emulator
-    devices: /dev/kvm
+    devices: [/dev/kvm]
     shm_size: 128M
     expose:
       - "5556"


### PR DESCRIPTION
This is required by latest docker-compose (v 1.24.1)

https://github.com/google/android-emulator-container-scripts/issues/19