### PR TITLE
Add support for exposing ADB in the webcontainer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,11 +232,24 @@ keep the following in mind:
 
 ## Running the emulator on the web
 
-Once you have taken care of the steps above you can create the containers as
-follows:
+Once you have taken care of the steps above you can create the containers using
+the `create_web_container.sh` script:
 
 ```sh
-    ./create_web_container.sh user1,passwd1,user2,passwd2,....
+    $ ./create_web_container.sh -h
+       usage: create_web_container.sh [-h] [-a] [-s] -p user1,pass1,user2,pass2,...
+
+       optional arguments:
+       -h        show this help message and exit.
+       -a        expose adb. Requires ~/.android/adbkey.pub to be available at run.
+       -s        start the container after creation.
+       -p        list of username password pairs.  Defaults to: [jansene,hello]
+```
+
+For example:
+
+```sh
+    ./create_web_container.sh -p user1,passwd1,user2,passwd2,....
 ```
 This will do the following:
 
@@ -254,6 +267,22 @@ You can now launch the container as follows:
 Point your browser to [localhost](http://localhost). You will likely get
 a warning due to the usage of the self signed certifcate. Once you accept the
 cert you should be able to login and start using the emulator.
+
+Keep the following things in mind when you make the emulator accessible over adb:
+
+- Port 5555 will be exposed in the container.
+- The container must have access to the file: `~/.android/adbkey.pub`. This is
+  the public key used by adb. If this file does not exist you can launch the
+  emulator once to generate one for you.
+- The adb client you use to connect to the container must have access to the
+  private key (~/.android/adbkey).  This is usually the case if you are on the same machine.
+- You must run: `adb connect ip-address-of-container:5555` before you can
+  interact with the device. For example:
+
+```sh
+    $ adb connect localhost:5555
+    $ adb shell getprop
+```
 
 ### Troubleshooting
 

--- a/aemu-container.code-workspace
+++ b/aemu-container.code-workspace
@@ -1,0 +1,13 @@
+{
+	"folders": [
+		{
+			"path": "js/src/android_emulation_control"
+		},
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		"python.formatting.provider": "black"
+	}
+}

--- a/emu/templates/launch-emulator.sh
+++ b/emu/templates/launch-emulator.sh
@@ -36,10 +36,10 @@ fi
 # First we place the adb secret in the right place if it exists
 mkdir -p /root/.android
 
-if [ -f "/run/secrets/adbkey" ]; then
+if [ -f "/run/secrets/adbkey.pub" ]; then
     echo "Copying key from secret partition"
-    cp /run/secrets/adbkey /root/.android
-    chmod 600 /root/.android/adbkey
+    cp /run/secrets/adbkey.pub /root/.android
+    chmod 600 /root/.android/adbkey.pub
 elif [ ! -z "${ADBKEY}" ]; then
     echo "Using provided secret"
     echo "-----BEGIN PRIVATE KEY-----" > /root/.android/adbkey
@@ -58,12 +58,13 @@ tail -f /tmp/pulseverbose.log -n +1 | sed 's/^/pulse: /g' &
 
 # All our ports are loopback devices, so setup a simple forwarder
 socat -d tcp-listen:5555,reuseaddr,fork tcp:127.0.0.1:6555 &
+socat -d tcp-listen:5556,reuseaddr,fork tcp:127.0.0.1:6556 &
 
 # Log all the video bridge interactions, note that his file comes into existence later on.
 echo 'video: It is safe to ignore the 2 warnings from tail. The file will come into existence soon.'
 tail --retry -f /tmp/android-unknown/goldfish_rtc_0 | sed 's/^/video: /g' &
 
 # Kick off the emulator
-exec emulator/emulator @Pixel2 -verbose -show-kernel -ports 6554,6555 -grpc 5556 -no-window -skip-adb-auth -logcat "*:v" {{extra}} "$@"
+exec emulator/emulator @Pixel2 -verbose -show-kernel -ports 6554,6555 -grpc 6556 -no-window -skip-adb-auth -logcat "*:v" {{extra}} "$@"
 
 # All done!

--- a/js/docker/docker-compose-with-adb.yaml
+++ b/js/docker/docker-compose-with-adb.yaml
@@ -1,0 +1,67 @@
+# This docker file composes the container to include the adb secret from ~/.android
+# This will enable you to access the device over adb.
+# It requires that the ~/.android/adbkey file exists where you launch the container.
+version: "3.7"
+services:
+
+  front-envoy:
+    build:
+      context: .
+      dockerfile: envoy.Dockerfile
+    networks:
+      - envoymesh
+    expose:
+      - "8080"
+      - "8001"
+      - "8443"
+    ports:
+      - "80:8080"
+      - "443:8443"
+      - "8001:8001"
+
+  emulator:
+    build:
+      context: ../../src
+      dockerfile: Dockerfile
+    networks:
+      envoymesh:
+        aliases:
+          - emulator
+    devices: [/dev/kvm]
+    shm_size: 128M
+    secrets:
+      - adbkey.pub
+    expose:
+      - "5556"
+      - "5555"
+    ports:
+      - "5555:5555"
+
+  jwt_signer:
+    build:
+      context: ../jwt-provider
+      dockerfile: Dockerfile
+    networks:
+      envoymesh:
+        aliases:
+          - jwt_signer
+    expose:
+      - "8080"
+
+  nginx:
+    build:
+      context: ..
+      dockerfile: docker/nginx.Dockerfile
+    networks:
+      envoymesh:
+        aliases:
+          - nginx
+    expose:
+      - "80"
+
+secrets:
+  adbkey.pub:
+    file: ~/.android/adbkey.pub
+
+networks:
+  envoymesh: {}


### PR DESCRIPTION
We add an additional dockerfile that exposes the adb port. This can be
used to deploy the emulator in a web container and make it accessible
over adb at the same time.

Note that this currently requires the ~/.android/adbkey to be in
existence on the machine where you are launching the web container.

The adb client used to connect to the device must have access to the
private key.

Includes a fix to forward the gRPC port when we launch without
certificates. (Needed for new canary builds)