### PR TITLE
Update emu_docker.py

### DIFF
--- a/emu/emu_docker.py
+++ b/emu/emu_docker.py
@@ -17,6 +17,7 @@
 import argparse
 import logging
 import os
+import sys
 
 import emu
 import emu.emu_downloads_menu as emu_downloads_menu


### PR DESCRIPTION
Fix trivia error (NameError: name 'sys' is not defined) when try to exit at selecting the system image