### PR TITLE
Disable authorization workflow in development mode

### DIFF
--- a/js/develop.sh
+++ b/js/develop.sh
@@ -8,7 +8,17 @@ killgroup(){
 }
 
 cd "$(dirname "$0")"
-docker build -t emu-dev-web develop
+BUILD_OS=$(uname -s)
+case $BUILD_OS in
+  Darwin)
+    echo "Building for Mac"
+    docker build -t emu-dev-web -f develop/Dockerfile.mac develop
+    ;;
+  *)
+    echo "Building for linux"
+    docker build -t emu-dev-web -f develop/Dockerfile.unix develop
+    ;;
+esac
 docker rm emu-dev-grpc-web
 docker run  -p 8080:8080 -p 8001:8001  --name emu-dev-grpc-web emu-dev-web &
 npm start &

--- a/js/develop/Dockerfile.mac
+++ b/js/develop/Dockerfile.mac
@@ -1,0 +1,19 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#FROM envoyproxy/envoy:latest
+FROM envoyproxy/envoy:latest
+
+# Workaround for linux missing host.docker.internal
+COPY ./envoy.yaml /etc/envoy/envoy.yaml
+CMD /usr/local/bin/envoy -c /etc/envoy/envoy.yaml

--- a/js/develop/Dockerfile.unix
+++ b/js/develop/Dockerfile.unix
@@ -15,6 +15,5 @@
 FROM envoyproxy/envoy:latest
 
 # Workaround for linux missing host.docker.internal
-RUN  echo "172.17.0.1 host.docker.internal" >> /etc/hosts
 COPY ./envoy.yaml /etc/envoy/envoy.yaml
-CMD /usr/local/bin/envoy -c /etc/envoy/envoy.yaml
+CMD echo "172.17.0.1 host.docker.internal" >> /etc/hosts && /usr/local/bin/envoy -c /etc/envoy/envoy.yaml

--- a/js/src/service/auth_service.js
+++ b/js/src/service/auth_service.js
@@ -130,7 +130,7 @@ export class TokenAuthService {
 export class NoAuthService {
   constructor() {
     this.events = new EventEmitter();
-    this.loggedin = false;
+    this.loggedin = true;
   }
 
   on = (name, fn) => {


### PR DESCRIPTION
We now disable the login authorization workflow in developer mode.
Includes a fix where the /etc/hosts file was overwritten in unix,
causing connection failures.

We now separate the linux & mac docker files to work around the naming
of the "local" machine. See https://docs.docker.com/docker-for-mac/networking/
and https://docs.docker.com/network/network-tutorial-standalone/ for
details on docker networking differences on mac/linux.