### PR TITLE
Implement --tag flag in create task

### DIFF
--- a/emu/docker_device.py
+++ b/emu/docker_device.py
@@ -76,7 +76,7 @@ class DockerDevice(object):
         try:
             api_client = docker.APIClient()
             logging.info(api_client.version())
-            result = api_client.build(path=self.dest, rm=True, decode=True)
+            result = api_client.build(path=self.dest, tag=self.repo, rm=True, decode=True)
             for entry in result:
                 if "stream" in entry:
                     sys.stdout.write(entry["stream"])

--- a/emu/docker_device.py
+++ b/emu/docker_device.py
@@ -30,10 +30,10 @@ class DockerDevice(object):
     run this as root, or have enabled sudoless docker.
     """
 
-    def __init__(self, emulator, sysimg, dest_dir, repo=""):
+    def __init__(self, emulator, sysimg, dest_dir, tag=""):
         self.sysimg = AndroidReleaseZip(sysimg)
         self.emulator = AndroidReleaseZip(emulator)
-        self.repo = repo
+        self.tag = tag
         self.dest = dest_dir
         self.env = Environment(loader=PackageLoader("emu", "templates"))
 
@@ -76,7 +76,7 @@ class DockerDevice(object):
         try:
             api_client = docker.APIClient()
             logging.info(api_client.version())
-            result = api_client.build(path=self.dest, tag=self.repo, rm=True, decode=True)
+            result = api_client.build(path=self.dest, tag=self.tag, rm=True, decode=True)
             for entry in result:
                 if "stream" in entry:
                     sys.stdout.write(entry["stream"])

--- a/emu/emu_docker.py
+++ b/emu/emu_docker.py
@@ -31,7 +31,7 @@ def list_images(_):
 
 def create_docker_image(args):
     """Create a directory containing all the necessary ingredients to construct a docker image."""
-    device = DockerDevice(args.emuzip, args.imgzip, args.dest, args.repo)
+    device = DockerDevice(args.emuzip, args.imgzip, args.dest, args.tag)
     device.create_docker_file(args.extra)
     img = device.create_container()
     if img and args.start:
@@ -86,7 +86,7 @@ def main():
     create_parser.add_argument(
         "--dest", default=os.path.join(os.getcwd(), "src"), help="Destination for the generated docker files"
     )
-    create_parser.add_argument("--repo", default="", help="Docker repository name")
+    create_parser.add_argument("--tag", default="", help="Docker image name")
     create_parser.add_argument(
         "--start",
         action="store_true",
@@ -114,7 +114,7 @@ def main():
         help="Starts the container after creating it. "
         "All exposed ports are forwarded, and your private adbkey (if available) is injected but not stored.",
     )
-    create_inter.add_argument("--repo", default="", help="Docker repository name")
+    create_inter.add_argument("--tag", default="", help="Docker image name")
     create_inter.set_defaults(func=create_docker_image_interactive)
 
     args = parser.parse_args()

--- a/emu/emu_docker.py
+++ b/emu/emu_docker.py
@@ -31,7 +31,7 @@ def list_images(_):
 
 def create_docker_image(args):
     """Create a directory containing all the necessary ingredients to construct a docker image."""
-    device = DockerDevice(args.emuzip, args.imgzip, args.dest)
+    device = DockerDevice(args.emuzip, args.imgzip, args.dest, args.repo)
     device.create_docker_file(args.extra)
     img = device.create_container()
     if img and args.start:
@@ -86,7 +86,7 @@ def main():
     create_parser.add_argument(
         "--dest", default=os.path.join(os.getcwd(), "src"), help="Destination for the generated docker files"
     )
-    create_parser.add_argument("--repo", default="unused", help="Docker repository name")
+    create_parser.add_argument("--repo", default="", help="Docker repository name")
     create_parser.add_argument(
         "--start",
         action="store_true",
@@ -114,7 +114,7 @@ def main():
         help="Starts the container after creating it. "
         "All exposed ports are forwarded, and your private adbkey (if available) is injected but not stored.",
     )
-    create_inter.add_argument("--repo", default="unused", help="Docker repository name")
+    create_inter.add_argument("--repo", default="", help="Docker repository name")
     create_inter.set_defaults(func=create_docker_image_interactive)
 
     args = parser.parse_args()


### PR DESCRIPTION
I found that the `--repo` flag wasn't working. With this PR it works.

This flag is very useful. If you don't have it you need to parse the output of `emu-docker` to get the id. If we support the flag we can use the name of the image directly.

Anyway, I think that we should rename `--repo` to `--tag`. Or maybe I missundertood what `--repo` should do. If so I can refactor my PR to keep `--repo` as before and create `--tag`.