### PR TITLE
Remove intermediate containers when building the image

### DIFF
--- a/emu/docker_device.py
+++ b/emu/docker_device.py
@@ -76,7 +76,7 @@ class DockerDevice(object):
         try:
             api_client = docker.APIClient()
             logging.info(api_client.version())
-            result = api_client.build(path=self.dest, decode=True)
+            result = api_client.build(path=self.dest, rm=True, decode=True)
             for entry in result:
                 if "stream" in entry:
                     sys.stdout.write(entry["stream"])


### PR DESCRIPTION
This is the default and expected behaviour when you use docker cli

Docker SDK for Python point that out at its own documentation: https://docker-py.readthedocs.io/en/stable/images.html#docker.models.images.ImageCollection.build