### PR TITLE
Add health endpoint

### DIFF
--- a/emu/docker_device.py
+++ b/emu/docker_device.py
@@ -175,6 +175,7 @@ class DockerDevice(object):
                 "api": self.sysimg.api(),
                 "abi": self.sysimg.abi(),
                 "cpu": self.sysimg.cpu(),
+                "gpu": self.sysimg.gpu(),
                 "emu_zip": os.path.basename(self.emulator.fname),
                 "emu_build_id": self.emulator.revision(),
                 "sysimg_zip": os.path.basename(self.sysimg.fname),

--- a/emu/emu_downloads_menu.py
+++ b/emu/emu_downloads_menu.py
@@ -116,6 +116,10 @@ class AndroidReleaseZip(object):
         """Returns the cpu architecture, derived from the abi."""
         return self.ABI_CPU_MAP[self.abi()]
 
+    def gpu(self):
+        """Returns whether or not the system has gpu support."""
+        return self.props.get("SystemImage.GpuSupport")
+
     def tag(self):
         """The tag associated with this release."""
         return self.props.get("SystemImage.TagId", "")

--- a/emu/templates/Dockerfile
+++ b/emu/templates/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Emulator & video bridge dependencies
     libc6 libdbus-1-3 libfontconfig1 libgcc1 \
     libpulse0 libtinfo5 libx11-6 libxcb1 libxdamage1 \
-    libnss3 libxcomposite1 libxcursor1 \
+    libnss3 libxcomposite1 libxcursor1 libxi6 \
     libxext6 libxfixes3 zlib1g libgl1 pulseaudio socat \
 # Enable turncfg through usage of curl
     curl ca-certificates && \
@@ -50,7 +50,6 @@ COPY launch-emulator.sh /android/sdk/
 COPY default.pa /android/sdk/
 COPY platform-tools/adb /android/sdk/platform-tools/adb
 COPY default.pa /etc/pulse/default.pa
-
 RUN gpasswd -a root audio && \
     chmod +x /android/sdk/launch-emulator.sh
 
@@ -69,13 +68,19 @@ ENV ANDROID_SDK_ROOT /android/sdk
 ENV ANDROID_AVD_HOME /android-home
 WORKDIR /android/sdk
 
-# Note, we will not be using gpu acceleration, nor will the emulator be visible.
 # You will need to make use of the grpc snapshot/webrtc functionality to actually interact with
 # the emulator.
 CMD ["/android/sdk/launch-emulator.sh"]
 
+# Note we should use gRPC status endpoint to check for health once the canary release is out.
+HEALTHCHECK --interval=30s --timeout=30s --start-period=30s --retries=3 CMD /android/sdk/platform-tools/adb -s emulator-6554 shell getprop dev.bootcomplete | grep "1"
+
 # Date frequently changes, so we place this in the last layer.
 LABEL maintainer="{{user}}" \
+      SystemImage.Abi={{abi}} \
+      SystemImage.TagId={{tag}} \
+      SystemImage.GpuSupport={{gpu}} \
+      AndroidVersion.ApiLevel={{api}} \
       com.google.android.emulator.build-date="{{date}}" \
       com.google.android.emulator.description="Pixel 2 Emulator, running API {{api}}" \
       com.google.android.emulator.version="{{tag}}-{{api}}-{{abi}}/{{emu_build_id}}"

--- a/run.sh
+++ b/run.sh
@@ -14,4 +14,4 @@
 CONTAINER_ID=$1
 shift
 PARAMS="$@"
-docker run -e "ADBKEY=$(cat ~/.android/adbkey)" -e "EMULATOR_PARAMS=${PARAMS}" --device /dev/kvm --publish 5556:5556/tcp --publish 5555:5555/tcp ${CONTAINER_ID}
+docker run -e "ADBKEY=$(cat ~/.android/adbkey)" -e "EMULATOR_PARAMS=-gpu swiftshader_indirect ${PARAMS}" --device /dev/kvm --publish 5556:5556/tcp --publish 5555:5555/tcp ${CONTAINER_ID}


### PR DESCRIPTION
The docker container can now report health status. The health status
indicated whether or not the emulator has successfully booted.

Currently this is retrieved by invoking ADB, this is likely going to be
deprecated soon in favor of the gRPC endpoint that is faster and more
accurate, esp with API level >28

Usage:

$ docker inspect <container-id> --format="{{json .State.Health}}"