### PR TITLE
Prevent early pulse audio termination.

### DIFF
--- a/emu/templates/Dockerfile
+++ b/emu/templates/Dockerfile
@@ -47,7 +47,6 @@ RUN mkdir -p /android/sdk/platforms && \
 # Make sure to place files that do not change often in the higher layers
 # as this will improve caching.
 COPY launch-emulator.sh /android/sdk/
-COPY default.pa /android/sdk/
 COPY platform-tools/adb /android/sdk/platform-tools/adb
 COPY default.pa /etc/pulse/default.pa
 

--- a/emu/templates/launch-emulator.sh
+++ b/emu/templates/launch-emulator.sh
@@ -51,11 +51,11 @@ else
 fi
 
 # We need pulse audio for the webrtc video bridge, let's configure it.
-mkdir -p ~/.config/pulse
+mkdir -p /root/.config/pulse
 export PULSE_SERVER=unix:/tmp/pulse-socket
-pulseaudio -D -vvvv --log-time=1 --log-target=newfile:/tmp/pulseverbose.log --log-time=1
+pulseaudio -D -vvvv --log-time=1 --log-target=newfile:/tmp/pulseverbose.log --log-time=1 --exit-idle-time=-1
 tail -f /tmp/pulseverbose.log -n +1 | sed 's/^/pulse: /g' &
-{ pactl list | sed 's/^/pulse: /g' ; } || echo "pulse: Unable to connect to pulse audio, WebRTC will not work."
+pactl list || exit 1
 
 # All our ports are loopback devices, so setup a simple forwarder
 socat -d tcp-listen:5555,reuseaddr,fork tcp:127.0.0.1:6555 &


### PR DESCRIPTION
It seems that the switch to the nvidia container, which is based of
ubuntu, caused a different default configuration for pulse audio to be
loaded. In this configuration it is possible for the daemon to exit if
no connections are active.

We now explicitly disable this from the commandline, making sure that
pulse audio sticks around.

Fixes #58