### PR TITLE
Always use downloaded ADB

### DIFF
--- a/emu/docker_device.py
+++ b/emu/docker_device.py
@@ -66,19 +66,9 @@ class DockerDevice(object):
 
     def _copy_adb_to(self, dest):
         """Find adb, or download it if needed."""
-        adb_loc = None
-        if "linux" in sys.platform:
-            adb_loc = os.path.join(os.environ.get("ANDROID_SDK_ROOT", ""), "platform-tools", "adb")
-            if not (os.path.exists(adb_loc) and os.access(adb_loc, os.X_OK)):
-                adb_loc = find_executable("adb")
-
-        if adb_loc is None:
-            logging.info("No local adb, retrieving platform-tools")
-            tools = PlatformTools()
-            tools.extract_adb(dest)
-        else:
-            logging.info("Copying %s to %s", adb_loc, dest)
-            shutil.copy2(adb_loc, dest)
+        logging.info("Retrieving platform-tools")
+        tools = PlatformTools()
+        tools.extract_adb(dest)
 
     def _read_adb_key(self):
         adb_path = os.path.expanduser("~/.android/adbkey")

--- a/tests/e2e/test_launch_containers.py
+++ b/tests/e2e/test_launch_containers.py
@@ -51,7 +51,6 @@ def test_build_container(channel, img):
 @pytest.mark.linux
 @pytest.mark.parametrize('channel, img', [('canary', 'Q'), ('stable', 'P')])
 def test_run_container(channel, img):
-    assert not "linux" in sys.platform
     assert docker.from_env().ping()
     with TempDir() as tmp:
         args = Arguments(channel, img, tmp, None, False, "")


### PR DESCRIPTION
We now always fetch the proper adb version remotely. This makes sure the
code path we follow on mac is the same as linux.

Fixes 69
Test: 12 passed, 1 warnings in 244.96s (0:04:04)