### PR TITLE
Add support for config override

### DIFF
--- a/emu/templates/avd/Pixel2.avd/config.ini
+++ b/emu/templates/avd/Pixel2.avd/config.ini
@@ -40,3 +40,6 @@ tag.id={{tag}}
 abi.type={{abi}}
 hw.cpu.arch={{cpu}}
 image.sysdir.1=system-images/android/{{abi}}/
+
+# End of default configuration
+

--- a/emu/templates/launch-emulator.sh
+++ b/emu/templates/launch-emulator.sh
@@ -50,6 +50,13 @@ else
     echo "No adb key provided.. You might not be able to connect to the emulator."
 fi
 
+# Override config settings that the user forcefully wants to override.
+if [ ! -z "${AVD_CONFIG}" ]; then
+  echo "Adding ${AVD_CONFIG} to config.ini"
+  echo "${AVD_CONFIG}" >> "/android-home/Pixel2.avd/config.ini"
+fi
+
+
 # We need pulse audio for the webrtc video bridge, let's configure it.
 mkdir -p /root/.config/pulse
 export PULSE_SERVER=unix:/tmp/pulse-socket


### PR DESCRIPTION
This enables adding properties to the avd configuration, which in turn
can be used to override existing properties.

For example:

docker run -e
"AVD_CONFIG=hw.lcd.height=200\nhw.lcd.width=20\nhw.cpu.ncore=8\n"
--device /dev/kvm --publish 5556:5556/tcp --publish 5555:5555/tcp
aemu:aemu

Will override the lcd settings and number of cores used.

Test: 12 passed, 1 warnings in 260.52s (0:04:20)