### PR TITLE
Explicitly request for gpu support

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,10 @@ of hardware acceleration you might have to install the NVIDIA docker extensions
 from [here](https://github.com/NVIDIA/nvidia-docker) if you are running
 an older version of docker (<19.03). You must make sure you have
 a minimal X installation if you are using a cloud instance. For example
-[Xvfb](https://en.wikipedia.org/wiki/Xvfb) can be used.
+[Xvfb](https://en.wikipedia.org/wiki/Xvfb) can be used. You must build the
+containers by passing in the --gpu flag:
+
+    emu-docker create canary Q --gpu
 
 You can now launch the emulator with the `run-with-gpu.sh` script:
 

--- a/emu/emu_docker.py
+++ b/emu/emu_docker.py
@@ -49,7 +49,7 @@ def create_docker_image(args):
     if not rel.is_emulator():
         raise Exception("{} is not a zip file with an emulator".format(imgzip))
 
-    device = DockerDevice(emuzip, imgzip, args.dest, args.tag)
+    device = DockerDevice(emuzip, imgzip, args.dest, args.gpu, args.tag)
     device.create_docker_file(args.extra)
     img = device.create_container()
     if img and args.start:
@@ -65,7 +65,7 @@ def create_docker_image_interactive(args):
 
     img_zip = img.download()
     emu_zip = emulator.download("linux")
-    device = DockerDevice(emu_zip, img_zip, args.dest)
+    device = DockerDevice(emu_zip, img_zip, args.dest, args.gpu)
     device.create_docker_file(args.extra)
     img = device.create_container()
     if img and args.start:
@@ -121,6 +121,7 @@ def main():
         "--dest", default=os.path.join(os.getcwd(), "src"), help="Destination for the generated docker files"
     )
     create_parser.add_argument("--tag", default="", help="Docker image name")
+    create_parser.add_argument("--gpu", action="store_true", help="Build an image with gpu drivers, providing hardware acceleration")
     create_parser.add_argument(
         "--start",
         action="store_true",
@@ -142,6 +143,7 @@ def main():
     create_inter.add_argument(
         "--dest", default=os.path.join(os.getcwd(), "src"), help="Destination for the generated docker files"
     )
+    create_inter.add_argument("--gpu", action="store_true", help="Build an image with gpu drivers, providing hardware acceleration")
     create_inter.add_argument(
         "--start",
         action="store_true",

--- a/emu/templates/Dockerfile
+++ b/emu/templates/Dockerfile
@@ -18,9 +18,7 @@ RUN apk add --update unzip
 COPY {{emu_zip}} /tmp/
 RUN unzip -u -o /tmp/{{emu_zip}} -d /emu/
 
-
-FROM nvidia/opengl:1.0-glvnd-runtime-ubuntu18.04 AS emulator
-ENV NVIDIA_DRIVER_CAPABILITIES ${NVIDIA_DRIVER_CAPABILITIES},display
+{{from_base_img}}
 
 # Install all the required emulator dependencies.
 # You can get these by running ./android/scripts/unix/run_tests.sh --verbose --verbose --debs | grep apt | sort -u

--- a/tests/e2e/test_launch_containers.py
+++ b/tests/e2e/test_launch_containers.py
@@ -32,15 +32,15 @@ from utils import TempDir, find_adb, find_free_port
 
 
 
-Arguments = collections.namedtuple("Args", "emuzip, imgzip, dest, tag, start, extra")
+Arguments = collections.namedtuple("Args", "emuzip, imgzip, dest, tag, start, extra, gpu")
 
 @pytest.mark.slow
 @pytest.mark.e2e
-@pytest.mark.parametrize('channel, img', [('canary', 'Q'), ('stable', 'P')])
-def test_build_container(channel, img):
+@pytest.mark.parametrize('channel, img, gpu', [('canary', 'Q', True), ('stable', 'P', False)])
+def test_build_container(channel, img, gpu):
     assert docker.from_env().ping()
     with TempDir() as tmp:
-        args = Arguments(channel, img, tmp, None, False, "")
+        args = Arguments(channel, img, tmp, None, False, "", gpu)
         device = emu_docker.create_docker_image(args)
         assert device.identity is not None
         client = docker.from_env()
@@ -49,11 +49,11 @@ def test_build_container(channel, img):
 @pytest.mark.slow
 @pytest.mark.e2e
 @pytest.mark.linux
-@pytest.mark.parametrize('channel, img', [('canary', 'Q'), ('stable', 'P')])
-def test_run_container(channel, img):
+@pytest.mark.parametrize('channel, img, gpu', [('canary', 'Q', True), ('stable', 'P', False)])
+def test_run_container(channel, img, gpu):
     assert docker.from_env().ping()
     with TempDir() as tmp:
-        args = Arguments(channel, img, tmp, None, False, "")
+        args = Arguments(channel, img, tmp, None, False, "", gpu)
         device = emu_docker.create_docker_image(args)
         port = find_free_port()
 


### PR DESCRIPTION
Some users report problems when the GPU drivers are enabled but not
used. We now add a --gpu flag to explicitly enable gpu driver support.

All tests succeed.
12 passed, 1 warnings in 281.25s (0:04:41)
Partially Fixes #79