### PR TITLE
Make packaging dependency explicit.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,17 @@ setup(
     # This field lists other packages that your project depends on to run.
     # Any package you put here will be installed by pip when your project is
     # installed, so they must be valid existing projects.
-    install_requires=["urlfetch", "jinja2", "console-menu", "tqdm", "docker", "appdirs", "click", "colorlog"],  # Optional
+    install_requires=[
+        "urlfetch",
+        "jinja2",
+        "console-menu",
+        "tqdm",
+        "docker",
+        "appdirs",
+        "click",
+        "colorlog",
+        "packaging",
+    ],  # Optional
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"
     # syntax, for example:


### PR DESCRIPTION
The packaging module provides the versioning module. This happened to be
globally available in my development machine and was not made an
explicit dependency.

Fixes #95