### PR TITLE
some shell fix and doc fix

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -23,9 +23,11 @@ PYTHON=python
 if [ ! -f "./venv/bin/activate" ]; then
   # Prefer python3 if it is available.
   if command -v python3 &>/dev/null; then
-    echo "Using python 3"
-    PYTHON=python3
-    $PYTHON -m venv venv
+     echo "Using python 3"
+     PYTHON=python3
+     $PYTHON -m venv venv
+     ./venv/bin/pip install --upgrade pip
+     ./venv/bin/pip install --upgrade setuptools
   else
     echo "Using python 2"
     command virtualenv &>/dev/null || { echo "This script relies on virtualenv, you can install it with 'pip install virtualenv' (https://virtualenv.pypa.io)"; return ; }
@@ -35,5 +37,5 @@ fi
 
 . ./venv/bin/activate
 $PYTHON setup.py develop
-
+pip show docker-compose 2>/dev/null || pip install docker-compose
 echo "Ready to run emu-docker!"

--- a/configure.sh
+++ b/configure.sh
@@ -26,16 +26,18 @@ if [ ! -f "./venv/bin/activate" ]; then
      echo "Using python 3"
      PYTHON=python3
      $PYTHON -m venv venv
-     ./venv/bin/pip install --upgrade pip
-     ./venv/bin/pip install --upgrade setuptools
+     [ -e ./venv/bin/pip ] && ./venv/bin/pip install --upgrade pip
+     [ -e ./venv/bin/pip ] && ./venv/bin/pip install --upgrade setuptools
   else
     echo "Using python 2"
     command virtualenv &>/dev/null || { echo "This script relies on virtualenv, you can install it with 'pip install virtualenv' (https://virtualenv.pypa.io)"; return ; }
     virtualenv venv
   fi
 fi
-
-. ./venv/bin/activate
-$PYTHON setup.py develop
-pip show docker-compose 2>/dev/null || pip install docker-compose
-echo "Ready to run emu-docker!"
+if [ -e ./venv/bin/activate ]; then
+   . ./venv/bin/activate
+   $PYTHON setup.py develop
+   pip show packaging &>/dev/null || pip install packaging
+   pip show docker-compose &>/dev/null || pip install docker-compose
+   echo "Ready to run emu-docker!"
+fi

--- a/configure.sh
+++ b/configure.sh
@@ -37,7 +37,5 @@ fi
 if [ -e ./venv/bin/activate ]; then
    . ./venv/bin/activate
    $PYTHON setup.py develop
-   pip show packaging &>/dev/null || pip install packaging
-   pip show docker-compose &>/dev/null || pip install docker-compose
    echo "Ready to run emu-docker!"
 fi

--- a/create_web_container.sh
+++ b/create_web_container.sh
@@ -38,7 +38,7 @@ generate_pub_adb() {
   # Generate the adb public key, if it does not exist
   if [ ! -f ~/.android/adbkey.pub ]; then
     local ADB=adb
-    if [ !   $(command -v $ADB >/dev/null 2>&1) ]; then
+    if [ ! command -v $ADB >/dev/null 2>&1 ]; then
        ADB=$ANDROID_SDK_ROOT/platform-tools/adb
        command -v $ADB >/dev/null 2>&1 || panic "No public adb key, and adb not found in $ADB, make sure ANDROID_SDK_ROOT is set!"
     fi

--- a/create_web_container.sh
+++ b/create_web_container.sh
@@ -36,7 +36,7 @@ panic() {
 
 generate_pub_adb() {
   # Generate the adb public key, if it does not exist
-  if [[ ! -f ~/.android/adbkey.pub ]]; then
+  if [ ! -f ~/.android/adbkey.pub ]; then
     local ADB=adb
     if [ !   $(command -v $ADB >/dev/null 2>&1) ]; then
        ADB=$ANDROID_SDK_ROOT/platform-tools/adb

--- a/js/README.md
+++ b/js/README.md
@@ -84,7 +84,7 @@ If for example you are running the emulator in a private Google GCE project, you
 
     - Produce a result on stdout.
     - Produce a result within 1000 ms.
-    - Produce a valid [JSON RTCConfiguration object](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection).
+    - Produce a valid [JSON RTCConfiguration object](https://developer.mozilla.org/en-US/docs/Web/API/RTCConfiguration).
     - That contain at least an "iceServers" array.
     - The exit value should be 0 on success
 


### PR DESCRIPTION
1、Missing python3-venv package will cause python -m venv venv execution to fail.
Resulting in files ./venv/bin/pip and ./venv/bin/activate not being generated.
So if it fails, no need to execute setup.py
2、/bin/sh(default use dash in ubuntu) not support [[]]
3、shell [ ! expression ] and [ ! $(expression) ] should be different