### PR TITLE
Enable embedding of private adb key, and opening of console.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ a minimal X installation if you are using a cloud instance. For example
 [Xvfb](https://en.wikipedia.org/wiki/Xvfb) can be used. You must build the
 containers by passing in the --gpu flag:
 
-    emu-docker create canary Q --gpu
+    emu-docker create stable Q --gpu
 
 You can now launch the emulator with the `run-with-gpu.sh` script:
 

--- a/configure.sh
+++ b/configure.sh
@@ -30,8 +30,8 @@ if [ ! -f "./venv/bin/activate" ]; then
      [ -e ./venv/bin/pip ] && ./venv/bin/pip install --upgrade setuptools
   else
     echo "Using python 2"
-    command virtualenv &>/dev/null || { echo "This script relies on virtualenv, you can install it with 'pip install virtualenv' (https://virtualenv.pypa.io)"; return ; }
-    virtualenv venv
+    $PYTHON -m virtualenv &>/dev/null || { echo "This script relies on virtualenv, you can install it with 'pip install virtualenv' (https://virtualenv.pypa.io)"; return ; }
+    $PYTHON -m virtualenv venv
   fi
 fi
 if [ -e ./venv/bin/activate ]; then

--- a/create_web_container.sh
+++ b/create_web_container.sh
@@ -22,7 +22,7 @@ help() {
 
        optional arguments:
        -h        show this help message and exit.
-       -a        expose adb. Requires ~/.android/adbkey.pub to be available at container launch
+       -a        expose adb. Requires ~/.android/adbkey to be available at container launch
        -s        start the container after creation.
        -p        list of username password pairs.  Defaults to: [${PASSWDS}]
 EOF
@@ -34,16 +34,16 @@ panic() {
   exit 1
 }
 
-generate_pub_adb() {
+generate_keys() {
   # Generate the adb public key, if it does not exist
-  if [ ! -f ~/.android/adbkey.pub ]; then
+  if [ ! -f ~/.android/adbkey ]; then
     local ADB=adb
     if [ ! command -v $ADB >/dev/null 2>&1 ]; then
        ADB=$ANDROID_SDK_ROOT/platform-tools/adb
-       command -v $ADB >/dev/null 2>&1 || panic "No public adb key, and adb not found in $ADB, make sure ANDROID_SDK_ROOT is set!"
+       command -v $ADB >/dev/null 2>&1 || panic "No adb key, and adb not found in $ADB, make sure ANDROID_SDK_ROOT is set!"
     fi
     echo "Creating public key from private key with $ADB"
-    $ADB pubkey  ~/.android/adbkey > ~/.android/adbkey.pub
+    $ADB keygen ~/.android/adbkey
   fi
 }
 
@@ -58,7 +58,7 @@ while getopts 'hasp:' flag; do
 done
 
 # Make sure we have all we need for adb to succeed.
-generate_pub_adb
+generate_keys
 
 . ./configure.sh >/dev/null
 

--- a/emu/emu_docker.py
+++ b/emu/emu_docker.py
@@ -39,21 +39,22 @@ def accept_licenses(args):
         [x.license for x in emu_downloads_menu.get_emus_info()]
         + [x.license for x in emu_downloads_menu.get_images_info()]
     )
-    licenses = [x for x in licenses if not x.is_accepted()]
-    if not licenses:
+    to_accept = [x for x in licenses if not x.is_accepted()]
+    if not to_accept:
+        print("\n\n".join([str(l) for l in licenses]))
         print("You have already accepted all licenses.")
         return
 
-    print("\n\n".join([str(l) for l in licenses]))
+    print("\n\n".join([str(l) for l in to_accept]))
     if args.accept or click.confirm("Do you accept the licenses?"):
-        for l in licenses:
+        for l in to_accept:
             l.force_accept()
 
 
 def create_docker_image(args):
     """Create a directory containing all the necessary ingredients to construct a docker image.
 
-    Returns the DockerDevice object.
+    Returns the created DockerDevice objects.
     """
 
     cfg = DockerConfig()
@@ -78,7 +79,7 @@ def create_docker_image(args):
     if emuzip[0] in ["stable", "canary", "all"]:
         emuzip = [x.download() for x in emu_downloads_menu.find_emulator(emuzip[0])]
 
-
+    devices = []
     for (img, emu) in itertools.product(imgzip, emuzip):
         logging.info("Processing %s, %s", img, emu)
         rel = emu_downloads_menu.AndroidReleaseZip(img)
@@ -95,7 +96,10 @@ def create_docker_image(args):
             device.launch(img)
         if args.push:
             device.push(img)
-        return device
+        devices.append(device)
+
+    return devices
+
 
 
 def create_docker_image_interactive(args):

--- a/emu/emu_downloads_menu.py
+++ b/emu/emu_downloads_menu.py
@@ -217,7 +217,8 @@ class License(object):
         self.cfg.accept_license(self.name)
 
     def __str__(self):
-        return self.text
+      # encode to utf-8 for python 2
+      return str(self.text.encode('utf-8'))
 
     def __hash__(self):
         return hash(self.name)

--- a/emu/templates/Dockerfile
+++ b/emu/templates/Dockerfile
@@ -55,9 +55,15 @@ COPY avd /android-home
 # This is currently an experimental feature, and is not easily configurable//
 # RUN --security=insecure cd /android/sdk && ./launch-emulator.sh -quit-after-boot 120
 
-# Open up adb & grpc port
+# This is the console port, you usually want to keep this closed.
+EXPOSE 5554
+
+# This is the ADB port, useful.
 EXPOSE 5555
-EXPOSE 5556
+
+# This is the gRPC port, also useful, we don't want ADB to incorrectly identify this.
+EXPOSE 8556
+
 ENV ANDROID_SDK_ROOT /android/sdk
 ENV ANDROID_AVD_HOME /android-home
 WORKDIR /android/sdk
@@ -71,7 +77,7 @@ HEALTHCHECK --interval=30s \
             --timeout=30s \
             --start-period=30s \
             --retries=3 \
-            CMD /android/sdk/platform-tools/adb -s emulator-6554 shell getprop dev.bootcomplete | grep "1"
+            CMD /android/sdk/platform-tools/adb shell getprop dev.bootcomplete | grep "1"
 
 FROM unzipper as sys_unzipper
 

--- a/emu/templates/launch-emulator.sh
+++ b/emu/templates/launch-emulator.sh
@@ -14,80 +14,124 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+log_version_info() {
+  # This function logs version info.
+  emulator/emulator -version | head -n 1 | sed -u 's/^/version: /g'
+  echo 'version: launch_script: {{version}}'
+  img=$ANDROID_SDK_ROOT/system-images/android
+  [ -f "$img/x86_64/source.properties" ] && cat "$img/x86_64/source.properties" | sed -u 's/^/version: /g'
+  [ -f "$img/x86/source.properties" ] && cat "$img/x86/source.properties" | sed -u 's/^/version: /g'
+}
 
-# Let's log the emulator,script and image  version.
-emulator/emulator -version | head -n 1 | sed -u 's/^/version: /g'
-echo 'version: launch_script: {{version}}'
-img=$ANDROID_SDK_ROOT/system-images/android
-[ -f "$img/x86_64/source.properties" ] && cat "$img/x86_64/source.properties"| sed -u 's/^/version: /g'
-[ -f "$img/x86/source.properties" ] && cat "$img/x86/source.properties"| sed -u 's/^/version: /g'
+install_adb_keys() {
+  # We do not want to keep adb secrets around, if the emulator
+  # ever created the secrets itself we will never be able to connect.
+  rm -f /root/.android/adbkey /root/.android/adbkey.pub
 
+  if [ -f "/run/secrets/adbkey" ]; then
+    echo "emulator: Copying private key from secret partition"
+    cp /run/secrets/adbkey /root/.android
+  elif [ ! -z "${ADBKEY}" ]; then
+    echo "emulator: Using provided adb private key"
+    echo "-----BEGIN PRIVATE KEY-----" >/root/.android/adbkey
+    echo $ADBKEY | tr " " "\\n" | sed -n "4,29p" >>/root/.android/adbkey
+    echo "-----END PRIVATE KEY-----" >>/root/.android/adbkey
+  else
+    echo "emulator: No adb key provided, creating internal one, you might not be able connect from adb."
+    adb keygen /root/.android/adbkey
+  fi
+  chmod 600 /root/.android/adbkey
+}
 
-# Delete any leftovers from hard exits.
-rm -rf /tmp/*
-rm -rf /android-home/Pixel2.avd/*.lock
+# Installs the console tokens, if any. The environment variable |TOKEN| will be
+# non empty if a token has been set.
+install_console_tokens() {
+  if [ -f "/run/secrets/token" ]; then
+    echo "emulator: Copying console token from secret partition"
+    cp /run/secrets/token /root/.emulator_console_auth_token
+    TOKEN=yes
+  elif [ ! -z "${TOKEN}" ]; then
+    echo "emulator: Using provided emulator console token"
+    echo ${TOKEN} >/root/.emulator_console_auth_token
+  else
+    echo "emulator: No console token provided, console disabled."
+  fi
 
-# We do not want to keep adb secrets around, if the emulator
-# ever created the secrets itself we will never be able to connect.
-rm /root/.android/adbkey
-rm /root/.android/adbkey.pub
+  if [ ! -z "${TOKEN}" ]; then
+    echo "emulator: forwarding the emulator console."
+    socat -d tcp-listen:5554,reuseaddr,fork tcp:127.0.0.1:5556 &
+  fi
+}
 
-# Check for core-dumps, that might be left over
-if ls core* 1> /dev/null 2>&1; then
-    echo "** WARNING ** WARNING ** WARNING **"
-    echo "Core dumps exist in this image. This means the emulator has crashed in the past."
-fi
+install_grpc_certs() {
+  if [[ -f "/run/secrets/emulator-grpc.cer" ]] && [[ -f "/run/secrets/emulator-grpc.key" ]]; then
+    echo "emulator: Copying cert from secret partition"
+    cp /run/secrets/emulator-grpc.cer /root/.android/emulator-grpc.cer
+    cp /run/secrets/emulator-grpc.key /root/.android/emulator-grpc.key
+  else
+    echo "emulator: No console token provided, console disabled."
+  fi
+}
 
-# First we place the adb secret in the right place if it exists
-mkdir -p /root/.android
+clean_up() {
+  # Delete any leftovers from hard exits.
+  rm -rf /tmp/*
+  rm -rf /android-home/Pixel2.avd/*.lock
 
-if [ -f "/run/secrets/adbkey.pub" ]; then
-    echo "Copying public key from secret partition"
-    cp /run/secrets/adbkey.pub /root/.android
-    chmod 600 /root/.android/adbkey.pub
-elif [ ! -z "${ADBKEY}" ]; then
-    echo "Using provided secret"
-    echo "-----BEGIN PRIVATE KEY-----" > /root/.android/adbkey
-    echo $ADBKEY | tr " " "\\n" | sed -n "4,29p" >> /root/.android/adbkey
-    echo "-----END PRIVATE KEY-----" >> /root/.android/adbkey
-    chmod 600 /root/.android/adbkey
-else
-    echo "No adb key provided.. You might not be able to connect to the emulator."
-fi
+  # Check for core-dumps, that might be left over
+  if ls core* 1>/dev/null 2>&1; then
+    echo "emulator: ** WARNING ** WARNING ** WARNING **"
+    echo "emulator: Core dumps exist in this image. This means the emulator has crashed in the past."
+  fi
+
+  mkdir -p /root/.android
+}
+
+setup_pulse_audio() {
+  # We need pulse audio for the webrtc video bridge, let's configure it.
+  mkdir -p /root/.config/pulse
+  export PULSE_SERVER=unix:/tmp/pulse-socket
+  pulseaudio -D -vvvv --log-time=1 --log-target=newfile:/tmp/pulseverbose.log --log-time=1 --exit-idle-time=-1
+  tail -f /tmp/pulseverbose.log -n +1 | sed -u 's/^/pulse: /g' &
+  pactl list || exit 1
+}
+
+forward_loggers() {
+  mkdir /tmp/android-unknown
+  mkfifo /tmp/android-unknown/kernel.log
+  mkfifo /tmp/android-unknown/logcat.log
+  echo "emulator: It is safe to ignore the warnings from tail. The files will come into existence soon."
+  tail --retry -f /tmp/android-unknown/goldfish_rtc_0 | sed -u 's/^/video: /g' &
+  cat /tmp/android-unknown/kernel.log | sed -u 's/^/kernel: /g' &
+  cat /tmp/android-unknown/logcat.log | sed -u 's/^/logcat: /g' &
+}
+
+# Let's log the emulator,script and image version.
+log_version_info
+clean_up
+install_console_tokens
+install_adb_keys
+install_grpc_certs
+setup_pulse_audio
+forward_loggers
 
 # Override config settings that the user forcefully wants to override.
 if [ ! -z "${AVD_CONFIG}" ]; then
   echo "Adding ${AVD_CONFIG} to config.ini"
-  echo "${AVD_CONFIG}" >> "/android-home/Pixel2.avd/config.ini"
+  echo "${AVD_CONFIG}" >>"/android-home/Pixel2.avd/config.ini"
 fi
-
-
-# We need pulse audio for the webrtc video bridge, let's configure it.
-mkdir -p /root/.config/pulse
-export PULSE_SERVER=unix:/tmp/pulse-socket
-pulseaudio -D -vvvv --log-time=1 --log-target=newfile:/tmp/pulseverbose.log --log-time=1 --exit-idle-time=-1
-tail -f /tmp/pulseverbose.log -n +1 | sed -u 's/^/pulse: /g' &
-pactl list || exit 1
-
 
 # Launch internal adb server, needed for our health check.
 # Once we have the grpc status point we can use that instead.
 /android/sdk/platform-tools/adb start-server
 
 # All our ports are loopback devices, so setup a simple forwarder
-socat -d tcp-listen:5555,reuseaddr,fork tcp:127.0.0.1:6555 &
-
-mkdir /tmp/android-unknown
-mkfifo /tmp/android-unknown/kernel.log
-mkfifo /tmp/android-unknown/logcat.log
-echo "emulator: It is safe to ignore the warnings from tail. The files will come into existence soon."
-tail --retry -f /tmp/android-unknown/goldfish_rtc_0 | sed -u 's/^/video: /g' &
-cat /tmp/android-unknown/kernel.log | sed -u 's/^/kernel: /g' &
-cat /tmp/android-unknown/logcat.log | sed -u 's/^/logcat: /g' &
+socat -d tcp-listen:5555,reuseaddr,fork tcp:127.0.0.1:5557 &
 
 # Kick off the emulator
-exec emulator/emulator @Pixel2 -no-audio -verbose -ports 6554,6555 \
-  -grpc 5556 -no-window -skip-adb-auth \
+exec emulator/emulator @Pixel2 -no-audio -verbose -wipe-data \
+  -ports 5556,5557 \
+  -grpc 8556 -no-window -skip-adb-auth \
   -shell-serial file:/tmp/android-unknown/kernel.log \
   -logcat-output /tmp/android-unknown/logcat.log \
   -gpu swiftshader_indirect \

--- a/js/docker/docker-compose-with-adb.yaml
+++ b/js/docker/docker-compose-with-adb.yaml
@@ -30,7 +30,7 @@ services:
     devices: [/dev/kvm]
     shm_size: 128M
     secrets:
-      - adbkey.pub
+      - adbkey
     expose:
       - "5556"
       - "5555"
@@ -60,8 +60,8 @@ services:
       - "80"
 
 secrets:
-  adbkey.pub:
-    file: ~/.android/adbkey.pub
+  adbkey:
+    file: ~/.android/adbkey
 
 networks:
   envoymesh: {}

--- a/js/docker/docker-compose.yaml
+++ b/js/docker/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
     devices: [/dev/kvm]
     shm_size: 128M
     expose:
-      - "5556"
+      - "8556"
 
   jwt_signer:
     build:

--- a/js/docker/envoy.yaml
+++ b/js/docker/envoy.yaml
@@ -44,7 +44,7 @@ static_resources:
               routes:
                 # This is the emulator endpoint for grpc requests.
               - match: { prefix: "/android.emulation.control.EmulatorController" }
-                route: 
+                route:
                    cluster: emulator_service_grpc
                    max_grpc_timeout: 0s
 
@@ -103,7 +103,7 @@ static_resources:
             address:
               socket_address:
                 address: emulator
-                port_value: 5556
+                port_value: 8556
   - name: jwt_signer
     connect_timeout: 0.250s
     type: strict_dns

--- a/run-with-gpu.sh
+++ b/run-with-gpu.sh
@@ -19,4 +19,4 @@ shift
 PARAMS="$@"
 # Allow display access from the container.
 xhost +si:localuser:root
-docker run --gpus all -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix -e "ADBKEY=$(cat ~/.android/adbkey)" -e "EMULATOR_PARAMS=-gpu host ${PARAMS}" --device /dev/kvm --publish 5556:5556/tcp --publish 5555:5555/tcp ${CONTAINER_ID}
+docker run --gpus all -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix  e "TOKEN=$(cat ~/.emulator_console_auth_token)" -e "ADBKEY=$(cat ~/.android/adbkey)" -e "EMULATOR_PARAMS=-gpu host ${PARAMS}" --device /dev/kvm --publish 8556:8556/tcp --publish 5555:8555/tcp ${CONTAINER_ID}

--- a/run.sh
+++ b/run.sh
@@ -14,4 +14,4 @@
 CONTAINER_ID=$1
 shift
 PARAMS="$@"
-docker run -e "ADBKEY=$(cat ~/.android/adbkey)" -e "EMULATOR_PARAMS=${PARAMS}" --device /dev/kvm --publish 5556:5556/tcp --publish 5555:5555/tcp ${CONTAINER_ID}
+docker run -e "TOKEN=$(cat ~/.emulator_console_auth_token)" -e "ADBKEY=$(cat ~/.android/adbkey)" -e "EMULATOR_PARAMS=${PARAMS}" --device /dev/kvm --publish 8556:8556/tcp --publish 5554:5554/tcp --publish 5555:5555/tcp ${CONTAINER_ID}

--- a/tests/e2e/test_launch_containers.py
+++ b/tests/e2e/test_launch_containers.py
@@ -43,10 +43,12 @@ def test_build_container(channel, img, gpu):
     with TempDir() as tmp:
         args = Arguments(channel, img, tmp, None, False, "", gpu, True, False, False, "aemu", False)
         emu_docker.accept_licenses(args)
-        device = emu_docker.create_docker_image(args)
-        assert device.identity is not None
-        client = docker.from_env()
-        assert client.images.get(device.identity) is not None
+        devices = emu_docker.create_docker_image(args)
+        assert devices
+        for device in devices:
+          assert device.identity is not None
+          client = docker.from_env()
+          assert client.images.get(device.identity) is not None
 
 @pytest.mark.slow
 @pytest.mark.e2e
@@ -57,37 +59,39 @@ def test_run_container(channel, img, gpu):
     with TempDir() as tmp:
         args = Arguments(channel, img, tmp, None, False, "", gpu, True, False, False, "aemu", False)
         emu_docker.accept_licenses(args)
-        device = emu_docker.create_docker_image(args)
-        port = find_free_port()
+        devices = emu_docker.create_docker_image(args)
+        assert devices
+        for device in devices:
+          port = find_free_port()
 
-        # Launch this thing.
-        device.launch(device.identity, port)
-        # Now we are going to insepct this thing.
-        api_client = device.get_api_client()
-        status = api_client.inspect_container(device.container.id)
-        state = status["State"]
-        assert state["Status"] == "running"
+          # Launch this thing.
+          device.launch(device.identity, port)
+          # Now we are going to insepct this thing.
+          api_client = device.get_api_client()
+          status = api_client.inspect_container(device.container.id)
+          state = status["State"]
+          assert state["Status"] == "running"
 
-        # Acceptable states:
-        # starting --> We are still launching
-        # healthy --> Yay, we booted! Good to go..
-        health = state["Health"]["Status"]
-        while health == "starting":
-            health = api_client.inspect_container(device.container.id)["State"]["Health"]["Status"]
+          # Acceptable states:
+          # starting --> We are still launching
+          # healthy --> Yay, we booted! Good to go..
+          health = state["Health"]["Status"]
+          while health == "starting":
+              health = api_client.inspect_container(device.container.id)["State"]["Health"]["Status"]
 
-        assert health == "healthy"
+          assert health == "healthy"
 
-        # Good, good.. From an internal perspective things look great.
-        # Can we connect with adb from outside the container?
-        adb = find_adb()
+          # Good, good.. From an internal perspective things look great.
+          # Can we connect with adb from outside the container?
+          adb = find_adb()
 
-        # Erase knowledge of existing devices.
-        subprocess.check_output([adb, "kill-server"])
-        name = "localhost:{}".format(port)
-        subprocess.check_output([adb, "connect", name])
+          # Erase knowledge of existing devices.
+          subprocess.check_output([adb, "kill-server"])
+          name = "localhost:{}".format(port)
+          subprocess.check_output([adb, "connect", name])
 
-        # Boot complete should be true..
-        res = subprocess.check_output([adb, "-s", name, "shell", "getprop", "dev.bootcomplete"])
-        assert "1" in str(res)
+          # Boot complete should be true..
+          res = subprocess.check_output([adb, "-s", name, "shell", "getprop", "dev.bootcomplete"])
+          assert "1" in str(res)
 
-        api_client.stop(device.container.id)
+          api_client.stop(device.container.id)


### PR DESCRIPTION
This enables embedding of the private adb key, vs. the public one.
The private key will guarantee that the embedded ADB executable can
always interact with the emulator.

- Cleans up the launcher script
- Fix python2 encoding issue
- Fix adb health failure when no key was present
- Always force clean booe

Test: Tox succeeds.
Fixes: #98