### PR TITLE
Use docker overlays + systemd support

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,13 +311,14 @@ the `create_web_container.sh` script:
 
 ```sh
 $ ./create_web_container.sh -h
-   usage: create_web_container.sh [-h] [-a] [-s] -p user1,pass1,user2,pass2,...
+   usage: create_web_container.sh [-h] [-a] [-s] [-i] -p user1,pass1,user2,pass2,...
 
    optional arguments:
    -h        show this help message and exit.
    -a        expose adb. Requires ~/.android/adbkey.pub to be available at run.
    -s        start the container after creation.
    -p        list of username password pairs.  Defaults to: [jansene,hello]
+   -i        install systemd service, with definition in /opt/emulator
 ```
 
 For example:
@@ -331,12 +332,21 @@ This will do the following:
 - Configure the token service to give access to the passed in users.
 - Generate a public and private key pair, used to encrypt/decrypt JWT tokens
 - Create the set of containers to interact with the emulator.
+- Note that the systemd service has only been tested on debian/ubuntu.
 
 You can now launch the container as follows:
 
 ```sh
 docker-compose -f js/docker/docker-compose.yaml up
 ```
+
+If you wish to make ADB available you can apply the overlay found in
+js/docker/development.yaml as follows:
+
+```sh
+docker-compose -f js/docker/docker-compose.yaml -f js/docker/development.yaml up
+```
+
 
 Point your browser to [localhost](http://localhost). You will likely get
 a warning due to the usage of the self signed certificate. Once you accept the
@@ -345,9 +355,8 @@ cert you should be able to login and start using the emulator.
 Keep the following things in mind when you make the emulator accessible over adb:
 
 - Port 5555 will be exposed in the container.
-- The container must have access to the file: `~/.android/adbkey.pub`. This is
-  the public key used by adb. If this file does not exist you can launch the
-  emulator once to generate one for you.
+- The container must have access to the file: `~/.android/adbkey`. This is
+  the *PRIVATE* key used by adb.
 - The adb client you use to connect to the container must have access to the
   private key (~/.android/adbkey).  This is usually the case if you are on the same machine.
 - You must run: `adb connect ip-address-of-container:5555` before you can

--- a/create_web_container.sh
+++ b/create_web_container.sh
@@ -13,46 +13,73 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DOCKER_YAML=js/docker/docker-compose.yaml
+DOCKER_YAML=js/docker/docker-compose-build.yaml
 PASSWDS="$USER,hello"
+
+# Fancy colors in the terminal
+if [ -t 1 ]; then
+    RED=$(tput setaf 1)
+    GREEN=$(tput setaf 2)
+    RESET=$(tput sgr0)
+else
+    RED=
+    GREEN=
+    RESET=
+fi
+
+approve() {
+    echo "${GREEN}I know what I'm doing..[y/n]?${RESET}"
+    old_stty_cfg=$(stty -g)
+    stty raw -echo
+    answer=$(head -c 1)
+    stty $old_stty_cfg # Careful playing with stty
+    if echo "$answer" | grep -iq "^y"; then
+        echo Yes
+    else
+        echo Ok, bye!
+        exit 1
+    fi
+}
 
 help() {
     cat <<EOF
-       usage: create_web_container.sh [-h] [-a] [-s] -p user1,pass1,user2,pass2,...
+       usage: create_web_container.sh [-h] [-a] [-s] [-i] -p user1,pass1,user2,pass2,...
 
        optional arguments:
        -h        show this help message and exit.
        -a        expose adb. Requires ~/.android/adbkey to be available at container launch
        -s        start the container after creation.
        -p        list of username password pairs.  Defaults to: [${PASSWDS}]
+       -i        install systemd service, with definition in /opt/emulator
 EOF
     exit 1
 }
 
 panic() {
-  echo $1
-  exit 1
+    echo $1
+    exit 1
 }
 
 generate_keys() {
-  # Generate the adb public key, if it does not exist
-  if [ ! -f ~/.android/adbkey ]; then
-    local ADB=adb
-    if [ ! command -v $ADB >/dev/null 2>&1 ]; then
-       ADB=$ANDROID_SDK_ROOT/platform-tools/adb
-       command -v $ADB >/dev/null 2>&1 || panic "No adb key, and adb not found in $ADB, make sure ANDROID_SDK_ROOT is set!"
+    # Generate the adb public key, if it does not exist
+    if [ ! -f ~/.android/adbkey ]; then
+        local ADB=adb
+        if [ ! command -v $ADB ] >/dev/null 2>&1; then
+            ADB=$ANDROID_SDK_ROOT/platform-tools/adb
+            command -v $ADB >/dev/null 2>&1 || panic "No adb key, and adb not found in $ADB, make sure ANDROID_SDK_ROOT is set!"
+        fi
+        echo "Creating public key from private key with $ADB"
+        $ADB keygen ~/.android/adbkey
     fi
-    echo "Creating public key from private key with $ADB"
-    $ADB keygen ~/.android/adbkey
-  fi
 }
 
-while getopts 'hasp:' flag; do
+while getopts 'hasip:' flag; do
     case "${flag}" in
-    a) DOCKER_YAML=js/docker/docker-compose-with-adb.yaml ;;
+    a) DOCKER_YAML="${DOCKER_YAML} -f js/docker/development.yaml" ;;
     p) PASSWDS="${OPTARG}" ;;
     h) help ;;
     s) START='yes' ;;
+    i) INSTALL='yes' ;;
     *) help ;;
     esac
 done
@@ -69,7 +96,6 @@ python gen-passwords.py --pairs "${PASSWDS}" || exit 1
 cp jwt_secrets_pub.jwks ../docker/certs/jwt_secrets_pub.jwks
 cd ../..
 
-
 # Copy the private adbkey over
 cp ~/.android/adbkey js/docker/certs
 
@@ -83,4 +109,23 @@ if [ "${START}" = "yes" ]; then
 else
     echo "Created container, you can launch it as follows:"
     echo "docker-compose -f ${DOCKER_YAML} up"
+fi
+
+if [ "${INSTALL}" = "yes" ]; then
+    echo "Installing created container as systemd service"
+    echo "This will copy the docker yaml files in /opt/emulator"
+    echo "Make the current adbkey available to the image"
+    echo "And activate the container as a systemd service."
+    approve
+
+    sudo mkdir -p /opt/emulator
+    sudo cp ~/.android/adbkey /opt/emulator/adbkey
+    sudo cp js/docker/docker-compose.yaml /opt/emulator/docker-compose.yaml
+    sudo cp js/docker/production.yaml /opt/emulator/docker-compose.override.yaml
+    sudo cp js/docker/emulator.service /etc/systemd/system/emulator.service
+    sudo touch /etc/ssl/certs/emulator-grpc.cer
+    sudo touch /etc/ssl/private/emulator-grpc.key
+    sudo systemctl daemon-reload
+    sudo systemctl enable emulator.service
+    sudo systemctl restart emulator.service
 fi

--- a/emu/templates/Dockerfile
+++ b/emu/templates/Dockerfile
@@ -11,13 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM alpine AS unzipper
-
-RUN apk add --update unzip
-
-COPY {{emu_zip}} /tmp/
-RUN unzip -u -o /tmp/{{emu_zip}} -d /emu/
-
 {{from_base_img}}
 
 # Install all the required emulator dependencies.
@@ -37,7 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Now we configure the user account under which we will be running the emulator
 RUN mkdir -p /android/sdk/platforms && \
     mkdir -p /android/sdk/platform-tools && \
-    mkdir -p /android/sdk/system-images && \
+    mkdir -p /android/sdk/system-images/android && \
     mkdir -p /android-home
 
 # Make sure to place files that do not change often in the higher layers
@@ -45,12 +38,13 @@ RUN mkdir -p /android/sdk/platforms && \
 COPY launch-emulator.sh /android/sdk/
 COPY platform-tools/adb /android/sdk/platform-tools/adb
 COPY default.pa /etc/pulse/default.pa
+
 RUN gpasswd -a root audio && \
     chmod +x /android/sdk/launch-emulator.sh /android/sdk/platform-tools/adb
 
-COPY --from=unzipper /emu/ /android/sdk/
-
-COPY avd /android-home
+COPY avd/ /android-home
+COPY emu/ /android/sdk/
+COPY sys/ /android/sdk/system-images/android/
 # Create an initial snapshot so we will boot fast next time around,
 # This is currently an experimental feature, and is not easily configurable//
 # RUN --security=insecure cd /android/sdk && ./launch-emulator.sh -quit-after-boot 120
@@ -79,14 +73,6 @@ HEALTHCHECK --interval=30s \
             --retries=3 \
             CMD /android/sdk/platform-tools/adb shell getprop dev.bootcomplete | grep "1"
 
-FROM unzipper as sys_unzipper
-
-COPY {{sysimg_zip}} /tmp/
-RUN unzip -u -o /tmp/{{sysimg_zip}} -d /sysimg/
-
-FROM emulator
-
-COPY --from=sys_unzipper /sysimg/ /android/sdk/system-images/android/
 # Date frequently changes, so we place this in the last layer.
 LABEL maintainer="{{user}}" \
       SystemImage.Abi={{abi}} \

--- a/emu/templates/launch-emulator.sh
+++ b/emu/templates/launch-emulator.sh
@@ -28,7 +28,7 @@ install_adb_keys() {
   # ever created the secrets itself we will never be able to connect.
   rm -f /root/.android/adbkey /root/.android/adbkey.pub
 
-  if [ -f "/run/secrets/adbkey" ]; then
+  if [ -s "/run/secrets/adbkey" ]; then
     echo "emulator: Copying private key from secret partition"
     cp /run/secrets/adbkey /root/.android
   elif [ ! -z "${ADBKEY}" ]; then
@@ -46,7 +46,7 @@ install_adb_keys() {
 # Installs the console tokens, if any. The environment variable |TOKEN| will be
 # non empty if a token has been set.
 install_console_tokens() {
-  if [ -f "/run/secrets/token" ]; then
+  if [ -s "/run/secrets/token" ]; then
     echo "emulator: Copying console token from secret partition"
     cp /run/secrets/token /root/.emulator_console_auth_token
     TOKEN=yes
@@ -64,13 +64,9 @@ install_console_tokens() {
 }
 
 install_grpc_certs() {
-  if [[ -f "/run/secrets/emulator-grpc.cer" ]] && [[ -f "/run/secrets/emulator-grpc.key" ]]; then
-    echo "emulator: Copying cert from secret partition"
-    cp /run/secrets/emulator-grpc.cer /root/.android/emulator-grpc.cer
-    cp /run/secrets/emulator-grpc.key /root/.android/emulator-grpc.key
-  else
-    echo "emulator: No console token provided, console disabled."
-  fi
+    # Copy certs if they exists and are not empty.
+    [ -s "/run/secrets/grpc_cer" ] && cp /run/secrets/grpc_cer /root/.android/emulator-grpc.cer
+    [ -s "/run/secrets/grpc_key" ] && cp /run/secrets/grpc_key /root/.android/emulator-grpc.key
 }
 
 clean_up() {

--- a/emu/templates/launch-emulator.sh
+++ b/emu/templates/launch-emulator.sh
@@ -128,8 +128,10 @@ socat -d tcp-listen:5555,reuseaddr,fork tcp:127.0.0.1:5557 &
 exec emulator/emulator @Pixel2 -no-audio -verbose -wipe-data \
   -ports 5556,5557 \
   -grpc 8556 -no-window -skip-adb-auth \
+  -no-snapshot \
   -shell-serial file:/tmp/android-unknown/kernel.log \
   -logcat-output /tmp/android-unknown/logcat.log \
+  -feature  AllowSnapshotMigration \
   -gpu swiftshader_indirect \
   {{extra}} ${EMULATOR_PARAMS} -qemu -append panic=1
 # All done!

--- a/js/docker/development.yaml
+++ b/js/docker/development.yaml
@@ -1,0 +1,15 @@
+# This docker has a series of overrides to expose the private adbkey as a secret.
+# It requires that the ~/.android/adbkey file exists where you launch the container.
+version: "3.7"
+services:
+  emulator:
+    secrets:
+      - adbkey
+    ports:
+      - "5555:5555"
+      - "5554:5554"
+
+
+secrets:
+  adbkey:
+    file: ~/.android/adbkey

--- a/js/docker/docker-compose-build.yaml
+++ b/js/docker/docker-compose-build.yaml
@@ -1,10 +1,7 @@
-# This docker file composes the container to include the adb secret from ~/.android
-# This will enable you to access the device over adb.
-# It requires that the ~/.android/adbkey file exists where you launch the container.
 version: "3.7"
 services:
-
   front-envoy:
+    image: emulator_envoy:latest
     build:
       context: .
       dockerfile: envoy.Dockerfile
@@ -20,6 +17,7 @@ services:
       - "8001:8001"
 
   emulator:
+    image: emulator_emulator:latest
     build:
       context: ../../src
       dockerfile: Dockerfile
@@ -29,15 +27,11 @@ services:
           - emulator
     devices: [/dev/kvm]
     shm_size: 128M
-    secrets:
-      - adbkey
     expose:
-      - "5556"
-      - "5555"
-    ports:
-      - "5555:5555"
+      - "8556"
 
   jwt_signer:
+    image: emulator_jwt_signer:latest
     build:
       context: ../jwt-provider
       dockerfile: Dockerfile
@@ -49,6 +43,7 @@ services:
       - "8080"
 
   nginx:
+    image: emulator_nginx:latest
     build:
       context: ..
       dockerfile: docker/nginx.Dockerfile
@@ -58,10 +53,6 @@ services:
           - nginx
     expose:
       - "80"
-
-secrets:
-  adbkey:
-    file: ~/.android/adbkey
 
 networks:
   envoymesh: {}

--- a/js/docker/docker-compose.yaml
+++ b/js/docker/docker-compose.yaml
@@ -1,10 +1,8 @@
 version: "3.7"
 services:
-
   front-envoy:
-    build:
-      context: .
-      dockerfile: envoy.Dockerfile
+    image: emulator_envoy:latest
+    container_name: emulator_envoy
     networks:
       - envoymesh
     expose:
@@ -17,9 +15,8 @@ services:
       - "8001:8001"
 
   emulator:
-    build:
-      context: ../../src
-      dockerfile: Dockerfile
+    image: emulator_emulator:latest
+    container_name: emulator_emulator
     networks:
       envoymesh:
         aliases:
@@ -30,9 +27,8 @@ services:
       - "8556"
 
   jwt_signer:
-    build:
-      context: ../jwt-provider
-      dockerfile: Dockerfile
+    image: emulator_jwt_signer:latest
+    container_name: emulator_jwt_signer
     networks:
       envoymesh:
         aliases:
@@ -40,19 +36,15 @@ services:
     expose:
       - "8080"
 
-
-
   nginx:
-    build:
-      context: ..
-      dockerfile: docker/nginx.Dockerfile
+    image: emulator_nginx:latest
+    container_name: emulator_nginx
     networks:
       envoymesh:
         aliases:
           - nginx
     expose:
       - "80"
-
 
 networks:
   envoymesh: {}

--- a/js/docker/emulator.service
+++ b/js/docker/emulator.service
@@ -15,6 +15,7 @@ ExecStartPre=-/bin/bash -c 'docker network ls -qf "name=emulator_" | xargs docke
 ExecStartPre=-/bin/bash -c 'docker ps -aqf "name=emulator_*" | xargs docker rm'
 # Compose up
 ExecStart=/usr/local/bin/docker-compose up
+ExecStartPost=/bin/bash -c 'echo "VIRTUAL_DEVICE_BOOT_STARTED"'
 
 # Compose down, remove containers and volumes
 ExecStop=/usr/local/bin/docker-compose down -v

--- a/js/docker/emulator.service
+++ b/js/docker/emulator.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Emulator adb service with docker compose
+Requires=docker.service
+After=docker.service
+
+[Service]
+Restart=always
+WorkingDirectory=/opt/emulator/
+
+# Remove old containers, images and volumes
+ExecStartPre=/usr/local/bin/docker-compose down -v
+ExecStartPre=/usr/local/bin/docker-compose rm -fv
+ExecStartPre=-/bin/bash -c 'docker volume ls -qf "name=emulator_" | xargs docker volume rm'
+ExecStartPre=-/bin/bash -c 'docker network ls -qf "name=emulator_" | xargs docker network rm'
+ExecStartPre=-/bin/bash -c 'docker ps -aqf "name=emulator_*" | xargs docker rm'
+# Compose up
+ExecStart=/usr/local/bin/docker-compose up
+
+# Compose down, remove containers and volumes
+ExecStop=/usr/local/bin/docker-compose down -v
+
+[Install]
+WantedBy=multi-user.target

--- a/js/docker/production.yaml
+++ b/js/docker/production.yaml
@@ -1,0 +1,14 @@
+# This docker has a series of overrides to expose the private adbkey as a secret.
+# It requires that the /opt/emulator/adbkey file exists where you launch the container.
+version: "3.7"
+services:
+  emulator:
+    secrets:
+      - adbkey
+    ports:
+      - "5555:5555"
+
+secrets:
+  adbkey:
+    file: /opt/emulator/adbkey
+


### PR DESCRIPTION
This seperates the docker deployment and build into two steps. This
enables for easy deployment in cloud based environments.

docker-compose-build.yaml is the build script that will create a series
of named images that can be used by the docker-compose script to launch
directly.

A systemd service script is provided to bring up the containers during
boot.

Tox:

py27: commands succeeded
py37: commands succeeded
congratulations :)