### PR TITLE
Pin envoy to version v1.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ with both Python version 2 and 3.
 
 *Note that this is still an experimental feature and we recommend installing
 this tool in a [python virtual environment](https://docs.python.org/3/tutorial/venv.html).
+Please file issues if you notice that anything is not working as expected.
 
 # Requirements
 

--- a/js/docker/envoy.Dockerfile
+++ b/js/docker/envoy.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #FROM envoyproxy/envoy:latest
-FROM envoyproxy/envoy:latest
+FROM envoyproxy/envoy:v1.12.0
 
 COPY ./envoy.yaml /etc/envoy/envoy.yaml
 ADD certs/self_sign.crt /etc/cert.crt


### PR DESCRIPTION
Pulling the latest version of envoy can easily break the default
configuration. We now pin to a specific version.

Fixes #106