### PR TITLE
Fix typo and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,16 +74,8 @@ You can now connect to the running device using adb:
 
 Do not forget to stop the docker container once you are done!
 
-If you wish to interact with the emulator via the web, and you have port 80 and
-443 available you can run:
-
-    docker-compose -f js/docker/docker-compose.yaml build
-
-After building the containers, you can launch the emulator as follows
-
-    docker-compose -f js/docker/docker-compose.yaml up
-
-The emulator should be available at [http://localhost](http://localhost).
+Read the [section](#Make-the-emulator-accessible-on-the-web) on making the emulator available on the web to run the emulator
+using webrtc
 
 ## Obtaining URLs for emulator/system image zip files
 

--- a/run-with-gpu.sh
+++ b/run-with-gpu.sh
@@ -19,4 +19,4 @@ shift
 PARAMS="$@"
 # Allow display access from the container.
 xhost +si:localuser:root
-docker run --gpus all -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix  e "TOKEN=$(cat ~/.emulator_console_auth_token)" -e "ADBKEY=$(cat ~/.android/adbkey)" -e "EMULATOR_PARAMS=-gpu host ${PARAMS}" --device /dev/kvm --publish 8556:8556/tcp --publish 5555:8555/tcp ${CONTAINER_ID}
+docker run --gpus all -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix  -e "TOKEN=$(cat ~/.emulator_console_auth_token)" -e "ADBKEY=$(cat ~/.android/adbkey)" -e "EMULATOR_PARAMS=-gpu host ${PARAMS}" --device /dev/kvm --publish 8556:8556/tcp --publish 5555:8555/tcp ${CONTAINER_ID}


### PR DESCRIPTION
Running the emulator in a web environment requires binplacing of
certificates. This is done by a shell script which was not reflected in
the documentation.

Running the emulator with hardware acceleration using the nvidia base
package was missing a dash in the shell script.

Fixes #111
Fixes #110