### PR TITLE
Add support for creating cloud builder releases

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -29,7 +29,7 @@ if [ ! -f "./venv/bin/activate" ]; then
      [ -e ./venv/bin/pip ] && ./venv/bin/pip install --upgrade pip
      [ -e ./venv/bin/pip ] && ./venv/bin/pip install --upgrade setuptools
   else
-    echo "Using python 2"
+    echo "Using python 2 ----<< Deprecated! See: https://python3statement.org/.."
     $PYTHON -m virtualenv &>/dev/null || { echo "This script relies on virtualenv, you can install it with 'pip install virtualenv' (https://virtualenv.pypa.io)"; return ; }
     $PYTHON -m virtualenv venv
   fi

--- a/emu/cloud_build.py
+++ b/emu/cloud_build.py
@@ -1,0 +1,79 @@
+# Copyright 2019 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import itertools
+import logging
+import os
+
+import yaml
+import click
+import colorlog
+
+import emu
+import emu.emu_downloads_menu as emu_downloads_menu
+from emu.docker_config import DockerConfig
+from emu.docker_device import DockerDevice
+from emu.template_writer import TemplateWriter
+
+
+def cloud_build(args):
+    licenses = set(
+        [x.license for x in emu_downloads_menu.get_emus_info()]
+        + [x.license for x in emu_downloads_menu.get_images_info()]
+    )
+
+    for l in licenses:
+        l.force_accept()
+
+    imgzip = [x.download() for x in emu_downloads_menu.find_image(args.img)]
+    emuzip = [x.download() for x in emu_downloads_menu.find_emulator("canary")]
+    devices = []
+
+    steps = []
+    images = []
+    emulators = set()
+
+    for (img, emu) in itertools.product(imgzip, emuzip):
+        logging.info("Processing %s, %s", img, emu)
+        img_rel = emu_downloads_menu.AndroidReleaseZip(img)
+        if not img_rel.is_system_image():
+            logging.warn("{} is not a zip file with a system image (Unexpected description), skipping".format(img))
+            continue
+        emu_rel = emu_downloads_menu.AndroidReleaseZip(emu)
+        if not emu_rel.is_emulator():
+            raise Exception("{} is not a zip file with an emulator".format(emu))
+
+        emulators.add(emu_rel.build_id())
+        for metrics in [True, False]:
+            name = img_rel.repo_friendly_name()
+            if not metrics:
+                name += "-no-metrics"
+
+            dest = os.path.join(args.dest, name)
+            logging.info("Generating %s", name)
+            device = DockerDevice(emu, img, dest, gpu=False, repo=args.repo, tag=emu_rel.build_id(), name=name)
+            device.create_docker_file("", metrics=True, by_copying_zip_files=True)
+            steps.append(device.create_cloud_build_step())
+            images.append(device.tag)
+
+    cloudbuild = {"steps": steps, "images": images}
+    with open(os.path.join(args.dest, "cloudbuild.yaml"), "w") as ymlfile:
+        yaml.dump(cloudbuild, ymlfile)
+
+    writer = TemplateWriter(args.dest)
+    writer.write_template(
+        "cloudbuild.README.MD",
+        {"emu_version": ", ".join(emulators), "emu_images": "\n".join(images)},
+        rename_as="README.MD",
+    )
+

--- a/emu/docker_config.py
+++ b/emu/docker_config.py
@@ -1,18 +1,18 @@
 # Lint as: python3
 # Copyright 2019 The Android Open Source Project
 #
-# labeld under the Apache label, Version 2.0 (the "label");
-# you may not use this file except in compliance with the label.
-# You may obtain a copy of the label at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#     http://www.apache.org/labels/label-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the label is distributed on an "AS IS" BASIS,
+# distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the label for the specific language governing permissions and
-# limitations under the label.
-"""Module that makes sure you have accepted the proper label.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Module that makes sure you have accepted the proper license.
 """
 from appdirs import user_config_dir
 import os
@@ -61,12 +61,9 @@ class DockerConfig(object):
         return label in self.cfg["DEFAULT"]
 
     def _save_config(self):
-        with open(self.cfg_file, 'w') as cfgfile:
+        with open(self.cfg_file, "w") as cfgfile:
             self.cfg.write(cfgfile)
 
     def _load_config(self):
         if os.path.exists(self.cfg_file):
             self.cfg.read(self.cfg_file)
-
-
-

--- a/emu/emu_docker.py
+++ b/emu/emu_docker.py
@@ -27,6 +27,8 @@ import emu
 import emu.emu_downloads_menu as emu_downloads_menu
 from emu.docker_config import DockerConfig
 from emu.docker_device import DockerDevice
+from emu.cloud_build import cloud_build
+from emu.utils import mkdir_p
 
 
 def list_images(args):
@@ -50,6 +52,9 @@ def accept_licenses(args):
         for l in to_accept:
             l.force_accept()
 
+
+def create_cloud_build_distribuition(args):
+    cloud_build(args)
 
 def create_docker_image(args):
     """Create a directory containing all the necessary ingredients to construct a docker image.
@@ -99,7 +104,6 @@ def create_docker_image(args):
         devices.append(device)
 
     return devices
-
 
 
 def create_docker_image_interactive(args):
@@ -234,6 +238,23 @@ def main():
     )
     create_inter.set_defaults(func=create_docker_image_interactive)
 
+    dist_parser = subparsers.add_parser(
+        "cloud-build",
+        help="Create a cloud builder distribution. This will create a distribution for publishing container images to a GCE repository."
+        "This is likely only useful if you are within Google.",
+    )
+    dist_parser.add_argument("--repo", default="", help="Repo prefix, for example: us.gcr.io/emu-dev/")
+    dist_parser.add_argument(
+        "--dest", default=os.path.join(os.getcwd(), "src"), help="Destination for the generated docker files"
+    )
+    dist_parser.add_argument(
+        "img",
+        default="P google_apis_playstore x86_64|Q google_apis_playstore x86_64",
+        help="A regexp matching the image to retrieve. "
+        "All the matching images will be selected when using a regex. "
+        'Use the list command to show all available images. For example "P google_apis_playstore x86_64".',
+    )
+    dist_parser.set_defaults(func=create_cloud_build_distribuition)
     args = parser.parse_args()
 
     # Configure logger.

--- a/emu/emu_downloads_menu.py
+++ b/emu/emu_downloads_menu.py
@@ -125,6 +125,8 @@ class AndroidReleaseZip(object):
         return self.props.get("SystemImage.Abi", "")
 
     def short_abi(self):
+        if self.abi() not in self.SHORT_MAP:
+            logging.error("%s not in short map", self)
         return self.SHORT_MAP[self.abi()]
 
     def cpu(self):
@@ -138,7 +140,7 @@ class AndroidReleaseZip(object):
     def tag(self):
         """The tag associated with this release."""
         tag = self.props.get("SystemImage.TagId", "")
-        if tag == "default":
+        if tag == "default" or tag.strip() == "":
             tag = "android"
         return tag
 
@@ -217,8 +219,8 @@ class License(object):
         self.cfg.accept_license(self.name)
 
     def __str__(self):
-      # encode to utf-8 for python 2
-      return str(self.text.encode('utf-8'))
+        # encode to utf-8 for python 2
+        return str(self.text.encode("utf-8"))
 
     def __hash__(self):
         return hash(self.name)

--- a/emu/template_writer.py
+++ b/emu/template_writer.py
@@ -1,0 +1,59 @@
+# Copyright 2020 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import errno
+import logging
+import os
+
+import docker
+from jinja2 import Environment, PackageLoader
+from packaging import version
+
+
+from emu.utils import mkdir_p
+
+import emu
+from emu.emu_downloads_menu import AndroidReleaseZip, PlatformTools
+
+
+class TemplateWriter(object):
+    """A Template writer uses jinja to fill in templates.
+
+    All the templates should live in the ./emu/templates directory.
+    """
+
+    def __init__(self, out_dir):
+        """Creates a template writer that writes templates to the out_dir
+
+           The out directory will be created if needed.
+        """
+        self.env = Environment(loader=PackageLoader("emu", "templates"))
+        self.dest = out_dir
+
+    def write_template(self, template_file, template_dict, rename_as=None):
+        """Fill out the given template, writing it to the destination directory."""
+        dest_name = rename_as if rename_as else template_file
+        return self._write_template_to(template_file, os.path.join(self.dest, dest_name), template_dict)
+
+
+    def _write_template_to(self, tmpl_file, dest_file, template_dict):
+        """Loads the the given template, writing it to the dest_file
+
+            Note: the template will be written {dest_dir}/{tmpl_file},
+            directories will be created if the do not yet exist.
+        """
+        template = self.env.get_template(tmpl_file)
+        mkdir_p(os.path.dirname(dest_file))
+        logging.info("Writing: %s -> %s with %s", tmpl_file, dest_file, template_dict)
+        with open(dest_file, "w") as dfile:
+            dfile.write(template.render(template_dict))

--- a/emu/templates/Dockerfile.from_zip
+++ b/emu/templates/Dockerfile.from_zip
@@ -1,0 +1,102 @@
+# Copyright 2020 - The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This template is specific for automated creation of cloud builder entries.
+# and is based on having docker unzip the entries. This is a much slower process
+# for creating images.
+FROM alpine AS unzipper
+
+RUN apk add --update unzip
+
+COPY {{emu_zip}} /tmp/
+RUN unzip -u -o /tmp/{{emu_zip}} -d /emu/
+
+FROM debian:stretch-slim AS emulator
+
+# Install all the required emulator dependencies.
+# You can get these by running ./android/scripts/unix/run_tests.sh --verbose --verbose --debs | grep apt | sort -u
+# pulse audio is needed due to some webrtc dependencies.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+# Emulator & video bridge dependencies
+    libc6 libdbus-1-3 libfontconfig1 libgcc1 \
+    libpulse0 libtinfo5 libx11-6 libxcb1 libxdamage1 \
+    libnss3 libxcomposite1 libxcursor1 libxi6 \
+    libxext6 libxfixes3 zlib1g libgl1 pulseaudio socat \
+# Enable turncfg through usage of curl
+    curl ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Now we configure the user account under which we will be running the emulator
+RUN mkdir -p /android/sdk/platforms && \
+    mkdir -p /android/sdk/platform-tools && \
+    mkdir -p /android/sdk/system-images && \
+    mkdir -p /android-home
+
+# Make sure to place files that do not change often in the higher layers
+# as this will improve caching.
+COPY launch-emulator.sh /android/sdk/
+COPY platform-tools/adb /android/sdk/platform-tools/adb
+COPY default.pa /etc/pulse/default.pa
+RUN gpasswd -a root audio && \
+    chmod +x /android/sdk/launch-emulator.sh /android/sdk/platform-tools/adb
+
+COPY --from=unzipper /emu/ /android/sdk/
+
+COPY avd /android-home
+# Create an initial snapshot so we will boot fast next time around,
+# This is currently an experimental feature, and is not easily configurable//
+# RUN --security=insecure cd /android/sdk && ./launch-emulator.sh -quit-after-boot 120
+
+# This is the console port, you usually want to keep this closed.
+EXPOSE 5554
+
+# This is the ADB port, useful.
+EXPOSE 5555
+
+# This is the gRPC port, also useful, we don't want ADB to incorrectly identify this.
+EXPOSE 8556
+
+ENV ANDROID_SDK_ROOT /android/sdk
+ENV ANDROID_AVD_HOME /android-home
+WORKDIR /android/sdk
+
+# You will need to make use of the grpc snapshot/webrtc functionality to actually interact with
+# the emulator.
+CMD ["/android/sdk/launch-emulator.sh"]
+
+# Note we should use gRPC status endpoint to check for health once the canary release is out.
+HEALTHCHECK --interval=30s \
+            --timeout=30s \
+            --start-period=30s \
+            --retries=3 \
+            CMD /android/sdk/platform-tools/adb shell getprop dev.bootcomplete | grep "1"
+
+FROM unzipper as sys_unzipper
+
+COPY {{sysimg_zip}} /tmp/
+RUN unzip -u -o /tmp/{{sysimg_zip}} -d /sysimg/
+
+FROM emulator
+
+COPY --from=sys_unzipper /sysimg/ /android/sdk/system-images/android/
+# Date frequently changes, so we place this in the last layer.
+LABEL maintainer="{{user}}" \
+      SystemImage.Abi={{abi}} \
+      SystemImage.TagId={{tag}} \
+      SystemImage.GpuSupport={{gpu}} \
+      AndroidVersion.ApiLevel={{api}} \
+      com.google.android.emulator.build-date="{{date}}" \
+      com.google.android.emulator.description="Pixel 2 Emulator, running API {{api}}" \
+      com.google.android.emulator.version="{{tag}}-{{api}}-{{abi}}/{{emu_build_id}}"

--- a/emu/templates/cloudbuild.README.MD
+++ b/emu/templates/cloudbuild.README.MD
@@ -1,0 +1,21 @@
+Release Notes
+=============
+
+This contains the release notes that accompanies the `cloudbuild.yaml` file.
+
+The yaml file will build:
+
+Emulator version: {{emu_version}}:
+
+{{emu_images}}
+
+
+## Building Locally
+
+Follow the instructions [here](https://cloud.google.com/cloud-build/docs/build-debug-locally) if
+you wish to build all the images locally.
+
+
+## TODO
+
+This file needs to be extended more details can be found here b/149339300

--- a/emu/utils.py
+++ b/emu/utils.py
@@ -1,0 +1,20 @@
+# Copyright 2019 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+def mkdir_p(path):
+    """Make directories recursively if path not exists."""
+    if not os.path.exists(path):
+        os.makedirs(path)

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ setup(
         "click",
         "colorlog",
         "packaging",
+        "pyyaml",
     ],  # Optional
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"

--- a/tests/test_template_writer.py
+++ b/tests/test_template_writer.py
@@ -1,0 +1,65 @@
+# Copyright 2019 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""Unit tests for the downloads_meu package.
+
+"""
+
+# Copyright 202 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Lint as: python3
+"""Unit tests for the template writer
+
+"""
+
+import unittest
+import tempfile
+import os
+import shutil
+
+from emu.template_writer import TemplateWriter
+
+
+class TemplateTest(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp("unittest")
+        self.writer = TemplateWriter(self.tmpdir)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def test_writer_writes_file(self):
+        self.writer.write_template("cloudbuild.README.MD", {})
+        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "cloudbuild.README.MD")))
+
+    def test_renames_file(self):
+        self.writer.write_template("cloudbuild.README.MD", {}, "foo")
+        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "foo")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This gets the script ready to prepare cloud builder images that
automatically can be pushed to GCE repositories.

This can be used to create self contained commits that can be pushed to
a repository, which in turn will trigger automated deployment of the
images.

This will enable the following workflow:

Emulator Release -> emu-docker cloud-build "(Q.*playstore.*64)"
/my/git/repo -> git push /my/git/repo -> new images that can be pulled.