### PR TITLE
Add support for git commits in cloudbuilder.

### DIFF
--- a/emu/emu_docker.py
+++ b/emu/emu_docker.py
@@ -56,6 +56,7 @@ def accept_licenses(args):
 def create_cloud_build_distribuition(args):
     cloud_build(args)
 
+
 def create_docker_image(args):
     """Create a directory containing all the necessary ingredients to construct a docker image.
 
@@ -247,6 +248,7 @@ def main():
     dist_parser.add_argument(
         "--dest", default=os.path.join(os.getcwd(), "src"), help="Destination for the generated docker files"
     )
+    dist_parser.add_argument("--git", action="store_true", help="Create a git commit, and push to destination.")
     dist_parser.add_argument(
         "img",
         default="P google_apis_playstore x86_64|Q google_apis_playstore x86_64",

--- a/emu/emu_downloads_menu.py
+++ b/emu/emu_downloads_menu.py
@@ -115,6 +115,8 @@ class AndroidReleaseZip(object):
 
     def codename(self):
         """First letter of the desert, if any."""
+        if 'AndroidVersion.CodeName' in self.props:
+            return self.props['AndroidVersion.CodeName']
         api = self.api()
         if api in API_LETTER_MAPPING:
             return API_LETTER_MAPPING[api]

--- a/emu/process.py
+++ b/emu/process.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+#
+# Copyright 2018 - The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the',  help='License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an',  help='AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import logging
+import platform
+
+try:
+    from queue import Queue
+except ImportError:
+    from Queue import Queue
+import subprocess
+from threading import Thread
+
+
+def _reader(pipe, queue):
+    try:
+        with pipe:
+            for line in iter(pipe.readline, b""):
+                queue.put((pipe, line[:-1]))
+    finally:
+        queue.put(None)
+
+
+def log_std_out(proc):
+    """Logs the output of the given process."""
+    q = Queue()
+    Thread(target=_reader, args=[proc.stdout, q]).start()
+    Thread(target=_reader, args=[proc.stderr, q]).start()
+    for _ in range(2):
+        for _, line in iter(q.get, None):
+            try:
+                logging.info(line.decode("utf-8"))
+            except IOError:
+                pass
+
+
+def run(cmd, cwd=None, extra_env=None):
+    if cwd:
+        cwd = os.path.abspath(cwd)
+
+    cmd = [str(c) for c in cmd]
+
+    logging.info("Running: %s in %s", " ".join(cmd), cwd)
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd, env=extra_env)
+
+    log_std_out(proc)
+    proc.wait()
+    if proc.returncode != 0:
+        raise Exception("Failed to run %s - %s" % (" ".join(cmd), proc.returncode))

--- a/emu/templates/cloudbuild.README.MD
+++ b/emu/templates/cloudbuild.README.MD
@@ -1,5 +1,7 @@
-Release Notes
-=============
+Emulator version: {{emu_version}}
+=================================
+
+## Release Notes
 
 This contains the release notes that accompanies the `cloudbuild.yaml` file.
 
@@ -14,8 +16,3 @@ Emulator version: {{emu_version}}:
 
 Follow the instructions [here](https://cloud.google.com/cloud-build/docs/build-debug-locally) if
 you wish to build all the images locally.
-
-
-## TODO
-
-This file needs to be extended more details can be found here b/149339300


### PR DESCRIPTION
This adds support for automatically creating git commits and pushing the
commits to the repository.

This enables emu-docker to be used as part of continuous deployment.