### PR TITLE
Make container creation idempotent

### DIFF
--- a/emu/templates/Dockerfile
+++ b/emu/templates/Dockerfile
@@ -79,6 +79,5 @@ LABEL maintainer="{{user}}" \
       SystemImage.TagId={{tag}} \
       SystemImage.GpuSupport={{gpu}} \
       AndroidVersion.ApiLevel={{api}} \
-      com.google.android.emulator.build-date="{{date}}" \
       com.google.android.emulator.description="Pixel 2 Emulator, running API {{api}}" \
       com.google.android.emulator.version="{{tag}}-{{api}}-{{abi}}/{{emu_build_id}}"

--- a/emu/templates/Dockerfile.from_zip
+++ b/emu/templates/Dockerfile.from_zip
@@ -97,6 +97,5 @@ LABEL maintainer="{{user}}" \
       SystemImage.TagId={{tag}} \
       SystemImage.GpuSupport={{gpu}} \
       AndroidVersion.ApiLevel={{api}} \
-      com.google.android.emulator.build-date="{{date}}" \
       com.google.android.emulator.description="Pixel 2 Emulator, running API {{api}}" \
       com.google.android.emulator.version="{{tag}}-{{api}}-{{abi}}/{{emu_build_id}}"


### PR DESCRIPTION
This makes running emu-docker idempotent when given the same emulator
version and system image.

This will make it easier to run emu-docker in automated environments.

Test:
 diff src/Dockerfile old/Dockerfile