### PR TITLE
Enable audio processing in emulator.

### DIFF
--- a/emu/templates/launch-emulator.sh
+++ b/emu/templates/launch-emulator.sh
@@ -125,7 +125,7 @@ fi
 socat -d tcp-listen:5555,reuseaddr,fork tcp:127.0.0.1:5557 &
 
 # Kick off the emulator
-exec emulator/emulator @Pixel2 -no-audio -verbose -wipe-data \
+exec emulator/emulator @Pixel2 -verbose -wipe-data \
   -ports 5556,5557 \
   -grpc 8554 -no-window -skip-adb-auth \
   -no-snapshot \

--- a/tests/e2e/test_cloud_build.py
+++ b/tests/e2e/test_cloud_build.py
@@ -26,7 +26,7 @@ from emu.cloud_build import cloud_build
 from utils import TempDir
 
 
-Arguments = collections.namedtuple("Args", "img, dest, repo")
+Arguments = collections.namedtuple("Args", "img, dest, repo, git")
 
 
 @pytest.mark.slow
@@ -35,7 +35,7 @@ def test_build_container():
     assert docker.from_env().ping()
     # Make sure we accept all licenses,
     with TempDir() as tmp:
-        args = Arguments("(P google_apis_playstore x86_64)|(Q google_apis x86_64)", tmp, "us.gcr.io/emu-dev-tst")
+        args = Arguments("(P google_apis_playstore x86_64)|(Q google_apis x86_64)", tmp, "us.gcr.io/emu-dev-tst", False)
         cloud_build(args)
         expected_files = [
             "cloudbuild.yaml",


### PR DESCRIPTION
This enables audio processing, which in turn will allow streaming of
audio with emulator version >=30.0.22

Test: 15 passed, 6 warnings in 491.57s (0:08:11)

Fixes #133 