### PR TITLE
Enable hosted docker container images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,24 @@ following requirements:
       to enable nested virtualization.
 
 Keep in mind that you will see reduced performance if you are making use of
-nested virtualization.
+nested virtualization. The containers have been tested under Debian and Ubuntu running kernel 5.2.17.
+
+*NOTE: The images will not run in docker on mac or windows*
+
+# Quick start with hosted containers.
+
+We now host a set of containers in a public repository. You can find details about the containers
+[here](REGISTRY.MD). You can now run these containers without building them. For example:
+
+```sh
+docker run \
+  -e "ADBKEY=$(cat ~/.android/adbkey)" --device /dev/kvm --publish \
+  8554:8554/tcp --publish 5555:5555/tcp  \
+  us-docker.pkg.dev/android-emulator-268719/images/r-google-x64:30.0.23
+```
+
+The section [below](#communicating-with-the-emulator-in-the-container) describes how
+to interact with the emulator.
 
 # Install in a virtual environment
 
@@ -79,7 +96,7 @@ To check if adb has seen the container, you can use the:
     adb devices
 
 command and check if a device is detected.
-    
+
 Do not forget to stop the docker container once you are done!
 
 Read the [section](#Make-the-emulator-accessible-on-the-web) on making the emulator available on the web to run the emulator
@@ -241,8 +258,6 @@ For example:
     docker run --device /dev/kvm --publish 8554:8554/tcp --publish 5555:5555/tcp \
     us.gcr.io/emulator-project/q-playstore-x86:29.3.2
 ```
-
-**Note: The projects above are samples, we are not yet hosting any of these images.**
 
 ## Communicating with the emulator in the container
 

--- a/REGISTRY.MD
+++ b/REGISTRY.MD
@@ -1,0 +1,88 @@
+## Android Emulator
+The Android Emulator simulates Android devices on your computer so that you can test your application on a variety of devices and Android API levels without needing to have each physical device.
+
+The emulator provides almost all of the capabilities of a real Android device. You can simulate incoming phone calls and text messages, specify the location of the device, simulate different network speeds, simulate rotation and other hardware sensors, access the Google Play Store, and much more.
+
+Testing your app on the emulator is in some ways faster and easier than doing so on a physical device.
+
+### Requirements and recommendations
+The docker images have the following requirements:
+
+- Linux only. Launching the emulator in Windows or MacOS is not supported.
+- KVM must be available. You can get access to KVM by running on "bare metal",
+  or on a (virtual) machine that provides [nested
+  virtualization](https://blog.turbonomic.com/blog/). If you are planning to run
+  this in the cloud (gce/azure/aws/etc..) you first must make sure you have
+  access to KVM. Details on how to get access to KVM on the various cloud
+  providers can be found here:
+
+    - AWS provides [bare
+      metal](https://aws.amazon.com/about-aws/whats-new/2019/02/introducing-five-new-amazon-ec2-bare-metal-instances/)
+      instances that provide access to KVM.
+    - Azure: Follow these
+      [instructions](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/nested-virtualization)
+      to enable nested virtualization.
+    - GCE: Follow these
+      [instructions](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances)
+      to enable nested virtualization.
+
+Keep in mind that you will see reduced performance if you are making use of nested virtualization.
+
+### Available images.
+
+Here is a list of the latest images.
+
+* us-docker.pkg.dev/android-emulator-268719/images/p-playstore-x64:30.0.23
+* us-docker.pkg.dev/android-emulator-268719/images/p-playstore-x64-no-metrics:30.0.23
+* us-docker.pkg.dev/android-emulator-268719/images/q-google-x64:30.0.23
+* us-docker.pkg.dev/android-emulator-268719/images/q-google-x64-no-metrics:30.0.23
+* us-docker.pkg.dev/android-emulator-268719/images/r-google-x64:30.0.23
+* us-docker.pkg.dev/android-emulator-268719/images/r-google-x64-no-metrics:30.0.23
+
+For example you can now pull a container as follows:
+
+    docker pull us-docker.pkg.dev/android-emulator-268719/images/p-playstore-x64:30.0.23
+
+### Usage
+
+The following environment variables are accepted by the emulator:
+
+ - `ADBKEY` This is the private adb key, needed if you wish to make use of adb. ADB is available on port 5555.
+
+The following ports are available:
+
+ - 5555: The [Android Debug Bridge (adb)](https://developer.android.com/studio/command-line/adb) port
+ - 8555: The gRPC port. This can be used by android studio and javascript endpoints.
+
+An example invocation making the console, adb and the gRPC endpoint available:
+```sh
+docker run -e "ADBKEY=$(cat ~/.android/adbkey)" --device /dev/kvm --publish 8554:8554/tcp --publish 5554:5554/tcp --publish 5555:5555/tcp us-docker.pkg.dev/android-emulator-268719/images/p-playstore-x64:30.0.23
+```
+
+You might need to run `adb connect localhost:5555` to enable ADB to discover the device.
+
+
+### License
+
+By making use of this container you accept the [Android Sdk License](https://developer.android.com/studio/terms)
+
+The android emulator is released under the [Apache-2 license](http://www.apache.org/licenses/LICENSE-2.0).
+
+The notices for the emulator and system image can be found in the following directories:
+
+-  /android/sdk/system-images/android/x86_64/NOTICE.txt
+-  /android/sdk/system-images/android/x86/NOTICE.txt
+-  /android/sdk/emulator/NOTICE.txt
+
+You can extract the notices as follows:
+
+    CONTAINER_ID=$(docker create name_of_image)
+    docker export $CONTAINER_ID | tar vxf -  --wildcards --no-anchored 'NOTICE.txt'
+
+
+For containers that do not have the -no-metrics you accept the following:
+
+By using this docker container you authorize Google to collect usage data for the Android Emulator
+— such as how you utilize its features and resources, and how you use it to test applications.
+This data helps improve the Android Emulator and is collected in accordance with
+[Google's Privacy Policy](http://www.google.com/policies/privacy/)

--- a/emu/templates/Dockerfile.from_zip
+++ b/emu/templates/Dockerfile.from_zip
@@ -16,9 +16,15 @@
 # and is based on having docker unzip the entries. This is a much slower process
 # for creating images.
 FROM alpine AS unzipper
-
 RUN apk add --update unzip
 
+# Barely changes
+FROM unzipper as sys_unzipper
+COPY {{sysimg_zip}} /tmp/
+RUN unzip -u -o /tmp/{{sysimg_zip}} -d /sysimg/
+
+# Changes per release.
+FROM unzipper as emu_unzipper
 COPY {{emu_zip}} /tmp/
 RUN unzip -u -o /tmp/{{emu_zip}} -d /emu/
 
@@ -46,13 +52,10 @@ RUN mkdir -p /android/sdk/platforms && \
 
 # Make sure to place files that do not change often in the higher layers
 # as this will improve caching.
-COPY launch-emulator.sh /android/sdk/
 COPY platform-tools/adb /android/sdk/platform-tools/adb
 COPY default.pa /etc/pulse/default.pa
 RUN gpasswd -a root audio && \
-    chmod +x /android/sdk/launch-emulator.sh /android/sdk/platform-tools/adb
-
-COPY --from=unzipper /emu/ /android/sdk/
+    chmod +x  /android/sdk/platform-tools/adb
 
 COPY avd /android-home
 # Create an initial snapshot so we will boot fast next time around,
@@ -83,14 +86,14 @@ HEALTHCHECK --interval=30s \
             --retries=3 \
             CMD /android/sdk/platform-tools/adb shell getprop dev.bootcomplete | grep "1"
 
-FROM unzipper as sys_unzipper
-
-COPY {{sysimg_zip}} /tmp/
-RUN unzip -u -o /tmp/{{sysimg_zip}} -d /sysimg/
 
 FROM emulator
 
 COPY --from=sys_unzipper /sysimg/ /android/sdk/system-images/android/
+COPY --from=emu_unzipper /emu/ /android/sdk/
+COPY launch-emulator.sh /android/sdk/
+RUN chmod +x /android/sdk/launch-emulator.sh /android/sdk/platform-tools/adb
+
 # Date frequently changes, so we place this in the last layer.
 LABEL maintainer="{{user}}" \
       SystemImage.Abi={{abi}} \

--- a/emu/templates/registry.README.MD
+++ b/emu/templates/registry.README.MD
@@ -1,0 +1,83 @@
+## Android Emulator
+The Android Emulator simulates Android devices on your computer so that you can test your application on a variety of devices and Android API levels without needing to have each physical device.
+
+The emulator provides almost all of the capabilities of a real Android device. You can simulate incoming phone calls and text messages, specify the location of the device, simulate different network speeds, simulate rotation and other hardware sensors, access the Google Play Store, and much more.
+
+Testing your app on the emulator is in some ways faster and easier than doing so on a physical device.
+
+### Requirements and recommendations
+The docker images have the following requirements:
+
+- Linux only. Launching the emulator in Windows or MacOS is not supported.
+- KVM must be available. You can get access to KVM by running on "bare metal",
+  or on a (virtual) machine that provides [nested
+  virtualization](https://blog.turbonomic.com/blog/). If you are planning to run
+  this in the cloud (gce/azure/aws/etc..) you first must make sure you have
+  access to KVM. Details on how to get access to KVM on the various cloud
+  providers can be found here:
+
+    - AWS provides [bare
+      metal](https://aws.amazon.com/about-aws/whats-new/2019/02/introducing-five-new-amazon-ec2-bare-metal-instances/)
+      instances that provide access to KVM.
+    - Azure: Follow these
+      [instructions](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/nested-virtualization)
+      to enable nested virtualization.
+    - GCE: Follow these
+      [instructions](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances)
+      to enable nested virtualization.
+
+Keep in mind that you will see reduced performance if you are making use of nested virtualization.
+
+### Available images.
+
+Here is a list of the latest images.
+
+{{emu_images}}
+
+For example you can now pull a container as follows:
+
+    docker pull {{first_image}}
+
+### Usage
+
+The following environment variables are accepted by the emulator:
+
+ - `ADBKEY` This is the private adb key, needed if you wish to make use of adb. ADB is available on port 5555.
+
+The following ports are available:
+
+ - 5555: The [Android Debug Bridge (adb)](https://developer.android.com/studio/command-line/adb) port
+ - 8555: The gRPC port. This can be used by android studio and javascript endpoints.
+
+An example invocation making the console, adb and the gRPC endpoint available:
+```sh
+docker run -e "ADBKEY=$(cat ~/.android/adbkey)" --device /dev/kvm --publish 8554:8554/tcp --publish 5554:5554/tcp --publish 5555:5555/tcp {{first_image}}
+```
+
+You might need to run `adb connect localhost:5555` to enable ADB to discover the device.
+
+
+### License
+
+By making use of this container you accept the [Android Sdk License](https://developer.android.com/studio/terms)
+
+The android emulator is released under the [Apache-2 license](http://www.apache.org/licenses/LICENSE-2.0).
+
+The notices for the emulator and system image can be found in the following directories:
+
+-  /android/sdk/system-images/android/x86_64/NOTICE.txt
+-  /android/sdk/system-images/android/x86/NOTICE.txt
+-  /android/sdk/emulator/NOTICE.txt
+
+You can extract the notices as follows:
+
+    CONTAINER_ID=$(docker create name_of_image)
+    docker export $CONTAINER_ID | tar vxf -  --wildcards --no-anchored 'NOTICE.txt'
+
+
+For containers that do not have the -no-metrics you accept the following:
+
+By using this docker container you authorize Google to collect usage data for the Android Emulator
+— such as how you utilize its features and resources, and how you use it to test applications.
+This data helps improve the Android Emulator and is collected in accordance with
+[Google's Privacy Policy](http://www.google.com/policies/privacy/)


### PR DESCRIPTION
This updates the documentation to reflect that we now host a subset of
all available images.