### PR TITLE
Add sample scripts and better quick start documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,44 @@ We now host a set of containers in a public repository. You can find details abo
 ```sh
 docker run \
   -e "ADBKEY=$(cat ~/.android/adbkey)" --device /dev/kvm --publish \
-  8554:8554/tcp --publish 5555:5555/tcp  \
+  8554:8554/tcp --publish 15555:5555/tcp  \
   us-docker.pkg.dev/android-emulator-268719/images/r-google-x64:30.0.23
 ```
 
-The section [below](#communicating-with-the-emulator-in-the-container) describes how
-to interact with the emulator.
+This will pull down the container if it is not locally available and launch it. You can see that is
+starting:
+
+After this you can connect to the device by configuring adb:
+
+```sh
+  adb connect localhost:15555
+```
+
+The device should now show up after a while as:
+
+```sh
+$ adb devices
+
+List of devices attached
+localhost:15555 device
+```
+
+If you wish to use this in a script you could do the following:
+
+```sh
+docker run -d \
+  -e "ADBKEY=$(cat ~/.android/adbkey)" --device /dev/kvm --publish \
+  8554:8554/tcp --publish 15555:5555/tcp  \
+  us-docker.pkg.dev/android-emulator-268719/images/r-google-x64:30.0.23
+  adb connect localhost:15555
+  adb wait-for-device
+
+  # The device is now booting, or close to be booted
+
+```
+
+A more detailed script can be found in [run-in-script-example.sh](./run-in-script-example.sh).
+
 
 # Install in a virtual environment
 
@@ -179,13 +211,13 @@ We provide the following run script:
 It does the following:
 
     docker run -e "ADBKEY=$(cat ~/.android/adbkey)" --device /dev/kvm --publish
-    8554:8554/tcp --publish 5555:5555/tcp <docker-image-id>
+    8554:8554/tcp --publish 15555:5555/tcp <docker-image-id>
 
 
 - Sets up the ADB key, assuming one exists at ~/.android/adbkey
 - Uses `--device /dev/kvm` to have CPU acceleration
 - Starts the emulator in the docker image with its gRPC service, forwarding the
-  host ports 8554/5555 to container ports 8554/5555 respectively.
+  host ports 8554/15555 to container ports 8554/5555 respectively.
 - The gRPC service is used to communicate with the running emulator inside the
   container.
 
@@ -254,7 +286,7 @@ For example:
 
 
 ```sh
-    docker run --device /dev/kvm --publish 8554:8554/tcp --publish 5555:5555/tcp \
+    docker run --device /dev/kvm --publish 8554:8554/tcp --publish 15555:5555/tcp \
     us.gcr.io/emulator-project/q-playstore-x86:29.3.2
 ```
 
@@ -274,7 +306,7 @@ Your device should now show up as:
 $ adb devices
 
 List of devices attached:
-emulator-5554   device
+localhost:5555 device
 ```
 
 # Make the emulator accessible on the web

--- a/run-in-script-example.sh
+++ b/run-in-script-example.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# This is the remote image we are going to run.
+# Docker will obtain it for us if needed.
+DOCKER_IMAGE=us-docker.pkg.dev/android-emulator-268719/images/r-google-x64:30.0.23
+
+# This is the forwarding port. Higher ports are preferred as to not interfere
+# with adb's ability to scan for emulators.
+PORT=15555
+
+# This will launch the container in the background.
+container_id=$(docker run -d \
+  -e "ADBKEY=$(cat ~/.android/adbkey)" --device /dev/kvm --publish \
+  8554:8554/tcp --publish $PORT:5555/tcp  \
+  $DOCKER_IMAGE)
+
+echo "The container is running with id: $container_id"
+
+# Note you might see something like:
+# failed to connect to localhost:15555
+# this merely indicates that the container is not yet ready.
+
+echo "Connecting to forwarded adb port."
+adb connect localhost:$PORT
+
+# we basically have to wait until `docker ps` shows us as healthy.
+# this can take a bit as the emulator needs to boot up!
+echo "Waiting until the device is ready"
+adb wait-for-device
+
+# The device is now booting, or close to be booted
+# We just wait until the sys.boot_completed property is set to 1.
+while [ "`adb shell getprop sys.boot_completed | tr -d '\r' `" != "1" ] ;
+do
+  echo "Still waiting for boot.."
+  sleep 1;
+done
+
+echo "The device is ready"
+echo "Run the following command to stop the container:"
+echo "docker stop ${container_id}"


### PR DESCRIPTION
This explains how to use the container in scripts when launching through
the hosted containers.