### PR TITLE
Add api level integer to repository naming

### DIFF
--- a/emu/emu_downloads_menu.py
+++ b/emu/emu_downloads_menu.py
@@ -165,7 +165,10 @@ class AndroidReleaseZip(object):
         return self.revision()
 
     def repo_friendly_name(self):
-        return "{}-{}-{}".format(self.codename().lower(), self.short_tag(), self.short_abi())
+        if len(self.api()) == 0:
+            return "{}-{}-{}".format(self.codename().lower(), self.short_tag(), self.short_abi())
+        else:
+            return "{}-{}-{}-{}".format(self.codename().lower(), self.api(), self.short_tag(), self.short_abi())
 
     def is_system_image(self):
         return "System Image" in self.desc()

--- a/emu/emu_downloads_menu.py
+++ b/emu/emu_downloads_menu.py
@@ -165,10 +165,10 @@ class AndroidReleaseZip(object):
         return self.revision()
 
     def repo_friendly_name(self):
-        if len(self.api()) == 0:
-            return "{}-{}-{}".format(self.codename().lower(), self.short_tag(), self.short_abi())
-        else:
-            return "{}-{}-{}-{}".format(self.codename().lower(), self.api(), self.short_tag(), self.short_abi())
+        prefix = self.api()
+        if len(prefix) == 0:
+            prefix = self.codename().lower()
+        return "{}-{}-{}".format(prefix, self.short_tag(), self.short_abi())
 
     def is_system_image(self):
         return "System Image" in self.desc()

--- a/emu/templates/Dockerfile
+++ b/emu/templates/Dockerfile
@@ -42,8 +42,8 @@ COPY default.pa /etc/pulse/default.pa
 RUN gpasswd -a root audio && \
     chmod +x /android/sdk/launch-emulator.sh /android/sdk/platform-tools/adb
 
-COPY avd/ /android-home
 COPY emu/ /android/sdk/
+COPY avd/ /android-home
 COPY sys/ /android/sdk/system-images/android/
 # Create an initial snapshot so we will boot fast next time around,
 # This is currently an experimental feature, and is not easily configurable//


### PR DESCRIPTION
This allows the repo naming to include an api level value if present in the properties file of the system image.

Does this really even need special behavior for the empty case? That seems unlikely to not have an api level value.

Potentially a breaking change for people depending on the existing format pattern.

closes #190 