### PR TITLE
Update documentation for TURN usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a set of minimal scripts to run the emulator in a container for various
 systems such as Docker, for external consumption. The scripts are compatible
 with both Python version 2 and 3.
 
-*Note that this is still an experimental feature and we recommend installing
+\*Note that this is still an experimental feature and we recommend installing
 this tool in a [python virtual environment](https://docs.python.org/3/tutorial/venv.html).
 Please file issues if you notice that anything is not working as expected.
 
@@ -19,7 +19,7 @@ following requirements:
   installing the command line tools is sufficient.
 - [Docker](https://docs.docker.com/v17.12/install/) must be installed. Make
   sure you can run it as [non-root
-  user]((https://docs.docker.com/install/linux/linux-postinstall/))
+  user](https://docs.docker.com/install/linux/linux-postinstall/)
 - [Docker-compose](https://docs.docker.com/compose/install/) must be installed.
 - KVM must be available. You can get access to KVM by running on "bare metal",
   or on a (virtual) machine that provides nested virtualization. If you are planning to run
@@ -27,20 +27,20 @@ following requirements:
   access to KVM. Details on how to get access to KVM on the various cloud
   providers can be found here:
 
-    - AWS provides [bare
-      metal](https://aws.amazon.com/about-aws/whats-new/2019/02/introducing-five-new-amazon-ec2-bare-metal-instances/)
-      instances that provide access to KVM.
-    - Azure: Follow these
-      [instructions](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/nested-virtualization)
-      to enable nested virtualization.
-    - GCE: Follow these
-      [instructions](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances)
-      to enable nested virtualization.
+  - AWS provides [bare
+    metal](https://aws.amazon.com/about-aws/whats-new/2019/02/introducing-five-new-amazon-ec2-bare-metal-instances/)
+    instances that provide access to KVM.
+  - Azure: Follow these
+    [instructions](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/nested-virtualization)
+    to enable nested virtualization.
+  - GCE: Follow these
+    [instructions](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances)
+    to enable nested virtualization.
 
 Keep in mind that you will see reduced performance if you are making use of
 nested virtualization. The containers have been tested under Debian and Ubuntu running kernel 5.2.17.
 
-*NOTE: The images will not run in docker on mac or windows*
+_NOTE: The images will not run in docker on mac or windows_
 
 # Quick start with hosted containers.
 
@@ -49,8 +49,10 @@ We now host a set of containers in a public repository. You can find details abo
 
 ```sh
 docker run \
-  -e "ADBKEY=$(cat ~/.android/adbkey)" --device /dev/kvm --publish \
-  8554:8554/tcp --publish 15555:5555/tcp  \
+  -e ADBKEY="$(cat ~/.android/adbkey)" \
+  --device /dev/kvm \
+  --publish 8554:8554/tcp \
+  --publish 5555:5555/tcp  \
   us-docker.pkg.dev/android-emulator-268719/images/r-google-x64:30.0.23
 ```
 
@@ -60,7 +62,7 @@ starting:
 After this you can connect to the device by configuring adb:
 
 ```sh
-  adb connect localhost:15555
+  adb connect localhost:5555
 ```
 
 The device should now show up after a while as:
@@ -69,17 +71,19 @@ The device should now show up after a while as:
 $ adb devices
 
 List of devices attached
-localhost:15555 device
+localhost:5555 device
 ```
 
 If you wish to use this in a script you could do the following:
 
 ```sh
 docker run -d \
-  -e "ADBKEY=$(cat ~/.android/adbkey)" --device /dev/kvm --publish \
-  8554:8554/tcp --publish 15555:5555/tcp  \
+  -e ADBKEY="$(cat ~/.android/adbkey)" \
+  --device /dev/kvm \
+  --publish 8554:8554/tcp \
+  --publish 5555:5555/tcp  \
   us-docker.pkg.dev/android-emulator-268719/images/r-google-x64:30.0.23
-  adb connect localhost:15555
+  adb connect localhost:5555
   adb wait-for-device
 
   # The device is now booting, or close to be booted
@@ -87,7 +91,6 @@ docker run -d \
 ```
 
 A more detailed script can be found in [run-in-script-example.sh](./run-in-script-example.sh).
-
 
 # Install in a virtual environment
 
@@ -101,8 +104,7 @@ follows:
 
     emu-docker -h
 
-You will need to accept the android licenses when you are creating images. You will have
-to accept the license agreements before you can create docker containers.
+You will have to accept the license agreements before you can create docker containers.
 
 ## Quick start, interactively creating and running a docker image
 
@@ -130,8 +132,8 @@ command and check if a device is detected.
 
 Do not forget to stop the docker container once you are done!
 
-Read the [section](#Make-the-emulator-accessible-on-the-web) on making the emulator available on the web to run the emulator
-using webrtc
+Read the [section](#Make-the-emulator-accessible-on-the-web) on making the
+emulator available on the web to run the emulator using webrtc
 
 ## Obtaining URLs for emulator/system image zip files
 
@@ -145,7 +147,7 @@ of:
 - Available and currently Docker-compatible system images
 - Currently published and advertised emulator binaries
 
-For each system image, the API level, variant, ABI, and URL are displayed.  For
+For each system image, the API level, variant, ABI, and URL are displayed. For
 each emulator, the update channel (stable vs canary), version, host os, and URL
 are displayed.
 
@@ -179,7 +181,7 @@ Example output:
     EMU canary 29.0.12 linux https://dl.google.com/android/repository/emulator-linux-5613046.zip
 
 One can then use tools like `wget` or a browser to download a desired emulator
-and system image.  After the two are obtained, we can build a Docker image.
+and system image. After the two are obtained, we can build a Docker image.
 
 Given an emulator zip file and a system image zip file, we can build a directory
 that can be sent to `docker build` via the following invocation of `emu-docker`:
@@ -210,13 +212,15 @@ We provide the following run script:
 
 It does the following:
 
-    docker run -e "TOKEN=$(cat ~/.emulator_console_auth_token)" -e "ADBKEY=$(cat ~/.android/adbkey)" -e "EMULATOR_PARAMS=${PARAMS}" --device /dev/kvm --publish 8554:8554/tcp --publish 5554:5554/tcp --publish 5555:5555/tcp ${CONTAINER_ID}
-
+    docker run -e ADBKEY="$(cat ~/.android/adbkey)" \
+    --device /dev/kvm \
+    --publish 8554:8554/tcp \
+    --publish 5555:5555/tcp <docker-image-id>
 
 - Sets up the ADB key, assuming one exists at ~/.android/adbkey
 - Uses `--device /dev/kvm` to have CPU acceleration
 - Starts the emulator in the docker image with its gRPC service, forwarding the
-  host ports 8554/6664/5555 to container ports 8554/5554/5555 respectively.
+  host ports 8554/5555 to container ports 8554/5555 respectively.
 - The gRPC service is used to communicate with the running emulator inside the
   container.
 
@@ -238,9 +242,9 @@ You can now launch the emulator with the `run-with-gpu.sh` script:
 
 The script is similar as to the one described above with the addition that it will:
 
-  - Make all the available gpu's available (`--gpu all`)
-  - Opens up xhost access for the container
-  - Enable the domain socket under /tmp/.X11-unix to communicate with hosts X server
+- Make all the available gpu's available (`--gpu all`)
+- Opens up xhost access for the container
+- Enable the domain socket under /tmp/.X11-unix to communicate with hosts X server
 
 Hardware acceleration will significantly improve performance of applications that heavily
 rely on graphics. Note that even though we need a X11 server for gpu acceleration there
@@ -260,19 +264,19 @@ We adopted the following naming scheme for images:
 Where:
 
 - desert is the desert letter
-- sort is one of: *aosp*, *google*, *playstore*
-    - *aosp*: A basic android open source image
-    - *google*: A system image that includes access to Google Play services.
-    - *playstore*: A system image that includes the Google Play Store app and access to Google Play services,
-                   including a Google Play tab in the Extended controls dialog that provides a
-                   convenient button for updating Google Play services on the device.
-- abi indicates the underlying CPU architecture, which is one of: *x86*, *x64*, *a32*, *a64*.
+- sort is one of: _aosp_, _google_, _playstore_
+  - _aosp_: A basic android open source image
+  - _google_: A system image that includes access to Google Play services.
+  - _playstore_: A system image that includes the Google Play Store app and access to Google Play services,
+    including a Google Play tab in the Extended controls dialog that provides a
+    convenient button for updating Google Play services on the device.
+- abi indicates the underlying CPU architecture, which is one of: _x86_, _x64_, _a32_, _a64_.
   Note that arm images are not hardware accelerated and might not be fast enough.
 
-For example: *q-playstore-x86:29.3.2* indicates a playstore enabled system image with Q running on 32-bit x86.
+For example: _q-playstore-x86:29.3.2_ indicates a playstore enabled system image with Q running on 32-bit x86.
 
-*Note: We are in the process of migrating from version number to emulator build numbers,
- which are more accurate*
+_Note: We are in the process of migrating from version number to emulator build numbers,
+which are more accurate_
 
 An example invocation for publishing all Q images to google cloud repo could be:
 
@@ -282,7 +286,6 @@ An example invocation for publishing all Q images to google cloud repo could be:
 
 Images that have been pushed to a repository can be launched directly from the repository.
 For example:
-
 
 ```sh
     docker run --device /dev/kvm --publish 8554:8554/tcp --publish 5555:5555/tcp \
@@ -315,13 +318,13 @@ composing the following set of docker containers:
 
 - [Envoy](https://www.envoyproxy.io/), an edge and service proxy: The proxy is
   responsible for the following:
-    - Offer TLS (https) using a self signed certificate
-    - Redirect traffic on port 80 (http) to port 443 (https)
-    - Act as a [gRPC proxy](https://grpc.io/blog/state-of-grpc-web/) for the
-      emulator.
-    - Verifying tokens to permit access to the emulator gRPC endpoint.
-    - Redirect other requests to the Nginx component which hosts
-      a [React](https://reactjs.org/) application.
+  - Offer TLS (https) using a self signed certificate
+  - Redirect traffic on port 80 (http) to port 443 (https)
+  - Act as a [gRPC proxy](https://grpc.io/blog/state-of-grpc-web/) for the
+    emulator.
+  - Verifying tokens to permit access to the emulator gRPC endpoint.
+  - Redirect other requests to the Nginx component which hosts
+    a [React](https://reactjs.org/) application.
 - [Nginx](https://www.nginx.com/), a webserver hosting a compiled React App
 - [Token Service](js/jwt-provider/README.md) a simple token service that hands out
   [JWT](https://en.wikipedia.org/wiki/JSON_Web_Token) tokens to grant access to the emulator.
@@ -333,13 +336,13 @@ In order to run this sample and be able to interact with the emulator you must
 keep the following in mind:
 
 - The demo has two methods to display the emulator.
-    1. Create an image every second, which is displayed in the browser. This
-    approach will always work, but gives poor performance.
-    2. Use [WebRTC](https://webrtc.org/) to display the state of the emulator in
-       real time. This will only work if you are able to create a peer to peer
-       connection to the server hosting the emulator. This is usually not
-       a problem when your server is publicly visible, or if you are running the
-       emulator on your own intranet.
+  1. Create an image every second, which is displayed in the browser. This
+     approach will always work, but gives poor performance.
+  2. Use [WebRTC](https://webrtc.org/) to display the state of the emulator in
+     real time. This will only work if you are able to create a peer to peer
+     connection to the server hosting the emulator. This is usually not
+     a problem when your server is publicly visible, or if you are running the
+     emulator on your own intranet.
 
 ## Requirements
 
@@ -348,22 +351,14 @@ keep the following in mind:
   internal network and expose the http and https ports.
 - You will need to create an emulator docker image, as described in the
   documentation above.
+- Depending on your network you might need [turn](js/turn/README.MD)
 
 ## Running the emulator on the web
 
-
 In order to create the web containers you must have the following tools available:
 
-- A protobuf compiler and headers
-- GNUmake
 - NodeJS
-- Package config
 - Npm
-
-On debian based systems you can install these as follows:
-
-    sudo apt-get install build-essential nodejs npm libprotoc-dev protobuf-compiler pkg-config
-
 
 Next you must create a container with the emulator & system image version you wish to
 use. For example:
@@ -392,6 +387,7 @@ For example:
 ```sh
 ./create_web_container.sh -p user1,passwd1,user2,passwd2,....
 ```
+
 This will do the following:
 
 - Create a virtual environment
@@ -413,7 +409,6 @@ js/docker/development.yaml as follows:
 docker-compose -f js/docker/docker-compose.yaml -f js/docker/development.yaml up
 ```
 
-
 Point your browser to [localhost](http://localhost). You will likely get
 a warning due to the usage of the self signed certificate. Once you accept the
 cert you should be able to login and start using the emulator.
@@ -422,9 +417,10 @@ Keep the following things in mind when you make the emulator accessible over adb
 
 - Port 5555 will be exposed in the container.
 - The container must have access to the file: `~/.android/adbkey`. This is
-  the *PRIVATE* key used by adb.
+  the _PRIVATE_ key used by adb. Without this you will not be able to access the device
+  over adb.
 - The adb client you use to connect to the container must have access to the
-  private key (~/.android/adbkey).  This is usually the case if you are on the same machine.
+  private key (~/.android/adbkey). This is usually the case if you are on the same machine.
 - You must run: `adb connect ip-address-of-container:5555` before you can
   interact with the device. For example:
 

--- a/emu/templates/launch-emulator.sh
+++ b/emu/templates/launch-emulator.sh
@@ -13,6 +13,78 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+VERBOSE=3
+
+
+# Return the value of a given named variable.
+# $1: variable name
+#
+# example:
+#    FOO=BAR
+#    BAR=ZOO
+#    echo `var_value $FOO`
+#    will print 'ZOO'
+#
+var_value () {
+    eval printf %s \"\$$1\"
+}
+
+
+# Return success if variable $1 is set and non-empty, failure otherwise.
+# $1: Variable name.
+# Usage example:
+#   if var_is_set FOO; then
+#      .. Do something the handle FOO condition.
+#   fi
+var_is_set () {
+    test -n "$(var_value $1)"
+}
+
+_var_quote_value () {
+    printf %s "$1" | sed -e "s|'|\\'\"'\"\\'|g"
+}
+
+
+# Append a space-separated list of items to a given variable.
+# $1: Variable name.
+# $2+: Variable value.
+# Example:
+#   FOO=
+#   var_append FOO foo    (FOO is now 'foo')
+#   var_append FOO bar    (FOO is now 'foo bar')
+#   var_append FOO zoo    (FOO is now 'foo bar zoo')
+var_append () {
+    local _var_append_varname
+    _var_append_varname=$1
+    shift
+    if test "$(var_value $_var_append_varname)"; then
+        eval $_var_append_varname=\$$_var_append_varname\'\ $(_var_quote_value "$*")\'
+    else
+        eval $_var_append_varname=\'$(_var_quote_value "$*")\'
+    fi
+}
+
+# Run a command, output depends on verbosity level
+run () {
+    if [ "$VERBOSE" -lt 0 ]; then
+        VERBOSE=0
+    fi
+    if [ "$VERBOSE" -gt 1 ]; then
+        echo "COMMAND: $@"
+    fi
+    case $VERBOSE in
+        0|1)
+             eval "$@" >/dev/null 2>&1
+             ;;
+        2)
+            eval "$@" >/dev/null
+            ;;
+        *)
+            eval "$@"
+            ;;
+    esac
+}
+
 
 log_version_info() {
   # This function logs version info.
@@ -26,11 +98,11 @@ log_version_info() {
 install_adb_keys() {
   # We do not want to keep adb secrets around, if the emulator
   # ever created the secrets itself we will never be able to connect.
-  rm -f /root/.android/adbkey /root/.android/adbkey.pub
+  run rm -f /root/.android/adbkey /root/.android/adbkey.pub
 
   if [ -s "/run/secrets/adbkey" ]; then
     echo "emulator: Copying private key from secret partition"
-    cp /run/secrets/adbkey /root/.android
+    run cp /run/secrets/adbkey /root/.android
   elif [ ! -z "${ADBKEY}" ]; then
     echo "emulator: Using provided adb private key"
     echo "-----BEGIN PRIVATE KEY-----" >/root/.android/adbkey
@@ -38,9 +110,9 @@ install_adb_keys() {
     echo "-----END PRIVATE KEY-----" >>/root/.android/adbkey
   else
     echo "emulator: No adb key provided, creating internal one, you might not be able connect from adb."
-    adb keygen /root/.android/adbkey
+    run adb keygen /root/.android/adbkey
   fi
-  chmod 600 /root/.android/adbkey
+  run chmod 600 /root/.android/adbkey
 }
 
 # Installs the console tokens, if any. The environment variable |TOKEN| will be
@@ -48,7 +120,7 @@ install_adb_keys() {
 install_console_tokens() {
   if [ -s "/run/secrets/token" ]; then
     echo "emulator: Copying console token from secret partition"
-    cp /run/secrets/token /root/.emulator_console_auth_token
+    run cp /run/secrets/token /root/.emulator_console_auth_token
     TOKEN=yes
   elif [ ! -z "${TOKEN}" ]; then
     echo "emulator: Using provided emulator console token"
@@ -71,8 +143,8 @@ install_grpc_certs() {
 
 clean_up() {
   # Delete any leftovers from hard exits.
-  rm -rf /tmp/*
-  rm -rf /android-home/Pixel2.avd/*.lock
+  run rm -rf /tmp/*
+  run rm -rf /android-home/Pixel2.avd/*.lock
 
   # Check for core-dumps, that might be left over
   if ls core* 1>/dev/null 2>&1; then
@@ -85,24 +157,24 @@ clean_up() {
 
 setup_pulse_audio() {
   # We need pulse audio for the webrtc video bridge, let's configure it.
-  mkdir -p /root/.config/pulse
+  run mkdir -p /root/.config/pulse
   export PULSE_SERVER=unix:/tmp/pulse-socket
-  pulseaudio -D -vvvv --log-time=1 --log-target=newfile:/tmp/pulseverbose.log --log-time=1 --exit-idle-time=-1
+  run pulseaudio -D -vvvv --log-time=1 --log-target=newfile:/tmp/pulseverbose.log --log-time=1 --exit-idle-time=-1
   tail -f /tmp/pulseverbose.log -n +1 | sed -u 's/^/pulse: /g' &
-  pactl list || exit 1
+  run pactl list || exit 1
 }
 
 forward_loggers() {
-  mkdir /tmp/android-unknown
-  mkfifo /tmp/android-unknown/kernel.log
-  mkfifo /tmp/android-unknown/logcat.log
+  run mkdir /tmp/android-unknown
+  run mkfifo /tmp/android-unknown/kernel.log
+  run mkfifo /tmp/android-unknown/logcat.log
   echo "emulator: It is safe to ignore the warnings from tail. The files will come into existence soon."
   tail --retry -f /tmp/android-unknown/goldfish_rtc_0 | sed -u 's/^/video: /g' &
   cat /tmp/android-unknown/kernel.log | sed -u 's/^/kernel: /g' &
   cat /tmp/android-unknown/logcat.log | sed -u 's/^/logcat: /g' &
 }
 
-# Let's log the emulator,script and image version.
+# Let us log the emulator,script and image version.
 log_version_info
 clean_up
 install_console_tokens
@@ -124,14 +196,27 @@ fi
 # All our ports are loopback devices, so setup a simple forwarder
 socat -d tcp-listen:5555,reuseaddr,fork tcp:127.0.0.1:5557 &
 
+# Basic launcher command, additional flags can be added.
+LAUNCH_CMD=emulator/emulator
+var_append LAUNCH_CMD -avd Pixel2 -verbose
+var_append LAUNCH_CMD -ports 5556,5557 -grpc 8554 -no-window
+var_append LAUNCH_CMD -skip-adb-auth -no-snapshot
+var_append LAUNCH_CMD -shell-serial file:/tmp/android-unknown/kernel.log
+var_append LAUNCH_CMD -logcat-output /tmp/android-unknown/logcat.log
+var_append LAUNCH_CMD -feature AllowSnapshotMigration
+var_append LAUNCH_CMD -gpu swiftshader_indirect {{extra}}
+
+if [ ! -z "${EMULATOR_PARAMS}" ]; then
+  var_append LAUNCH_CMD $EMULATOR_PARAMS
+fi
+
+if [ ! -z "${TURN}" ]; then
+  var_append LAUNCH_CMD -turncfg \'${TURN}\'
+fi
+
+# Add qemu specific parameters
+var_append LAUNCH_CMD -qemu -append panic=1
+
 # Kick off the emulator
-exec emulator/emulator @Pixel2 -verbose -wipe-data \
-  -ports 5556,5557 \
-  -grpc 8554 -no-window -skip-adb-auth \
-  -no-snapshot \
-  -shell-serial file:/tmp/android-unknown/kernel.log \
-  -logcat-output /tmp/android-unknown/logcat.log \
-  -feature  AllowSnapshotMigration \
-  -gpu swiftshader_indirect \
-  {{extra}} ${EMULATOR_PARAMS} -qemu -append panic=1
+run $LAUNCH_CMD
 # All done!

--- a/js/README.md
+++ b/js/README.md
@@ -16,43 +16,10 @@ For fast video over [WebRTC](www.webrtc.org):
 
 ### Do I need TURN?
 
-The most important thing to is to figure out if you need a [Turn Server](https://en.wikipedia.org/wiki/Traversal_Using_Relays_around_NAT). **You usually only need this if your server running the emulator is behind a firewall, and not publicly accessible.** Most of the time there is no need for a turn server.
-
-If for example you are running the emulator in a private Google GCE project, you will need to make use of a turn server. You can take the following steps to enable turn:
-
-1. Enable a turn service. There are many services you could use. A quick [Google search](https://www.google.com/search?q=webrtc+turn+server+cloud+providers) will provide a series of provides. If you are internal at google you could use the [GCE turn api](http://go/turnaas).
-2. Launch the emulator with the `-turncfg` flag.
-
-   This will inform the videobridge to execute the given command for every new incoming connection to obtain the JSON turn configuration that will be used.
-
-    This command must do the following:
-
-    - Produce a result on stdout.
-    - Produce a result within 1000 ms.
-    - Produce a valid [JSON RTCConfiguration object](https://developer.mozilla.org/en-US/docs/Web/API/RTCConfiguration).
-    - That contain at least an "iceServers" array.
-    - The exit value should be 0 on success
-
-    For example:
-
-    ```sh
-    emulator -grpc 8554 -turncfg "curl -s -X POST https://networktraversal.googleapis.com/v1alpha/iceconfig?key=MySec"
-    ```
-
-You can create the docker container with the `--extra` flag to pass in the turn configuration. For example:
-
-```sh
-emu-docker create stable \
-           "O google_apis_playstore x86" \
-           --extra  \
-           '-turncfg "curl -s -X POST https://networktraversal.googleapis.com/v1alpha/iceconfig?key=mykey"' \
-           --metrics
-```
-
-Would use the given curl command to obtain the the json snippet.
-
-*NOTE: If you do not obtain ice configuration through curl you might need to modify the docker template
-to make sure you can obtain the proper turn configuration.8
+The most important thing to is to figure out if you need a [Turn Server](https://en.wikipedia.org/wiki/Traversal_Using_Relays_around_NAT).
+**You usually only need this if your server running the emulator is behind a firewall, and not publicly accessible.**
+Most of the time there is no need for a turn server. If you do have needs for a turn server you can follow the steps in the
+[README](turn/README.MD).
 
 # Internal Organization
 

--- a/js/turn/README.MD
+++ b/js/turn/README.MD
@@ -1,0 +1,218 @@
+# Using a TURN server
+
+This document describes how you can use a turn server and includes a simple
+example of how you could deploy your own. You would need a turn server if you
+are running the emulator in network that is not publicly accessible.
+
+To enable turn you must have the following:
+
+- A publicly accessible turn server.
+- A mechanism to create a JSON turn configuration snippet the emulator can give
+  to the browser clients.
+
+Keep in mind that a savvy user could extract this snippet from the browser. Do not hand out permanent valid configurations
+if you do not trust your end users. A malicious user could use your TURN server for their own relay.
+
+## Quick start turn server.
+
+In this example we will use [coturn](https://github.com/coturn/coturn) as our turn server that uses a fixed set of credentials. You can use this configuration if you trust your users, or if you quickly want to test something.
+
+1.  Launch the turn server that is publicly accessible (say my.turn.org):
+
+    In the example below we are using an _insecure_ turn server. You should at least
+    provide a configuration file with passwords if you are going to deploy this.
+
+    ```sh
+    export TURN_SERVER="localhost" # This should be your real host name!
+    turnserver -v -n --log-file=stdout  -r $TURN_SERVER
+    ```
+
+    You can find details on using long term credentials in turn [here](https://github.com/coturn/coturn/wiki/README).
+
+2.  Create the json snippet, that provides access:
+
+    ```js
+    {
+      "iceServers": [
+        {
+          "urls": "turn:$TURN_SERVER",
+          "username": "webrtc",
+          "credential": "turnpassword",
+        },
+      ];
+    }
+    ```
+
+    Note that the username and password depend on how you configured your turn server and
+    are not needed if you are running an insecure server.
+
+3.  Launch the emulator container with the turncfg flag with the snippet as a single line:
+
+    ```sh
+    export SNIPPET="{\"iceServers\":[{\"urls\":\"turn:$TURN_SERVER\",\"username\":\"webrtc\",\"credential\":\"turnpassword\"}]}"
+    docker run  \
+     -e ADBKEY="$(cat ~/.android/adbkey)" \
+     -e TURN="printf $SNIPPET" \
+     --device /dev/kvm  \
+     --publish 8554:8554/tcp \
+     --publish 5555:5555/tcp ${CONTAINER_ID}
+    ```
+
+    If you wish to confirm that this is working properly you can check the docker logs for a line like this:
+
+    ```sh
+    docker logs my_container_id | grep Switchboard.cpp
+    video: (Switchboard.cpp:264): Sending {"msg":"{\"start\":{\"iceServers\":[{\"credential\":\"turnpassword\",\"urls\":\"turn:\",\"username\":\"webrtc\"}]}}","topic":"c6965c12-8b72-45c3-bc7d-f8143488382a"}
+    ```
+
+## Quick start using secure turn with temporary credentials
+
+In this example we will use [coturn](https://github.com/coturn/coturn) as our turn server, and we will use a simple python rest api to provide us with a secure configuration. The emulator will call the rest api which in turn will create a valid configuration that the turn server accepts.
+
+For this you will need:
+
+- A public coTURN server.
+- A shared secret between the coTURN server and the Python REST api
+- A shared secret between the Python REST api and the emulator.
+- [jq](https://stedolan.github.io/jq/), used to quickly test your config
+- [coturn](https://github.com/coturn/coturn), you will use the utilities to test and the server.
+
+1. Launch the Python REST api server. This does not have to be public, but must
+   be accessible by the emulator (say turn_key.provider.org)
+
+   ```sh
+   export API_KEY="a_secret_the_emulator_needs"
+   export SECRET="a_secret_that_the_turn_server_needs"
+   python turn.py --turn_secret $SECRET --api_key $API_KEY --port 8080
+   ```
+
+   Make sure that the api server works and is accessible, for example
+
+   ```sh
+   export API_SERVER=http://turn_key.provider.org
+   curl -s $API_SERVER/turn/localhost?apiKey=$API_KEY
+   ```
+
+   Should return something like this:
+
+   ```js
+   {"iceServers":[{"credential":"dFSc+Cg119PBHBx+qodUPI/19ic=","urls":["turn:localhost"],"username":"1598484959:someone"}]}
+   ```
+
+2. Launch the turn server that is publicly accessible (say my.turn.org):
+
+   ```sh
+   export TURN_SERVER="localhost" # This should be your real host name!
+   turnserver -v -n --log-file=stdout \
+        --use-auth-secret --static-auth-secret=$SECRET -r $TURN_SERVER
+   ```
+
+   Make sure your turn server is properly configured by making sure
+   you can connect with the generated JSON config from the previous step:
+
+   Using [jq](https://stedolan.github.io/jq/) we can construct our test:
+
+   ```sh
+   curl -s "http://localhost:8123/turn/localhost?apiKey=$API_KEY" | \
+   jq '.iceServers[0] | "turnutils_uclient -w \(.credential) -u \(.username) $TURN_SERVER"'
+   ```
+
+   Now copy paste the result and execute the command, if all went well you should see results.
+   For example:
+
+   ```sh
+   $ turnutils_uclient -w GH7ON8EceVvLtr96vSIB6unYBRM= -u 1598489324:someone   localhost
+
+   0: Total connect time is 0
+   1: start_mclient: msz=2, tot_send_msgs=0, tot_recv_msgs=0, tot_send_bytes ~ 0, tot_recv_bytes ~ 0
+   2: start_mclient: msz=2, tot_send_msgs=4, tot_recv_msgs=0, tot_send_bytes ~ 400, tot_recv_bytes ~ 0
+   3: start_mclient: msz=2, tot_send_msgs=5, tot_recv_msgs=0, tot_send_bytes ~ 500, tot_recv_bytes ~ 0
+   4: start_mclient: msz=2, tot_send_msgs=5, tot_recv_msgs=0, tot_send_bytes ~ 500, tot_recv_bytes ~ 0
+   5: start_mclient: msz=2, tot_send_msgs=5, tot_recv_msgs=0, tot_send_bytes ~ 500, tot_recv_bytes ~ 0
+   ```
+
+   Congratulations! You have a secure working turn server.
+
+3. Launch the emulator container with the turncfg flag:
+
+   ```sh
+   docker run  \
+    -e ADBKEY="$(cat ~/.android/adbkey)" \
+    -e TURN="curl -s $TURN_API/turn/$TURN_SERVER\?apiKey=$API_KEY" \
+    --device /dev/kvm  \
+    --publish 8554:8554/tcp \
+    --publish 5555:5555/tcp ${CONTAINER_ID}
+   ```
+
+   You should now be able to launch the web application which should make use of your turn service.
+   If all went well you should see loglines such as these:
+
+   ```
+   emulator: INFO: RtcService.cpp:98: RtcPacket: id { guid: "6da5cc46-7afc-4409-a77c-315dfe418f83" } message: "{\"start\":{\"iceServers\":[{\"credential\":\"mzddNrUmJcvp9Xg4q1ttzasd8Qk=\",\"urls\":[\"turn:localhost\"],\"username\":\"1598489788:someone\"}]}}"
+   ```
+
+   The emulator is informing your client to use your turn server
+
+## Custom configurations
+
+The emulator has support for turn if you have a command that does the following:
+
+- Produce a result on stdout.
+- Produce a result within 1000 ms.
+- Produce a valid [JSON RTCConfiguration object](https://developer.mozilla.org/en-US/docs/Web/API/RTCConfiguration).
+- That contains at least an "iceServers" array.
+- The exit value should be 0 on success
+
+This command can be passed in with the -turncfg parameter to the emulator. For example:
+
+```sh
+emulator -grpc 8554 -turncfg 'printf {"iceServers":[{"urls":["stun:stun.l.google.com:19302"]}]}'
+```
+
+This will use the standard stun server that Google provides. In general we support two approaches out of the box:
+
+- A static configuration: You can use `printf` as shown above to produce the static snippet.
+- A dynamic configuration: The emulator container ships with `curl`, which can be used to obtain a snippet.
+  Make sure to pass in the `-s` flag to keep curl silent.
+
+Both approaches can meet the requirements mentioned above.
+
+### Enable turn in containers.
+
+There are two ways in which we can embed the turn configuration inside the emulator:
+
+- **During run time:** Each time when we launch the emulator we add a flag.
+
+  You can pass in additional parameters to the emulator by setting
+  `TURN` environment variable in the container you wish to launch.
+  The environment variable should contain the command you wish to execute to
+  obtain the turn configuration, for example you could use curl to obtain a
+  a snippet:
+
+  ```sh
+    docker run  \
+     -e ADBKEY="$(cat ~/.android/adbkey)" \
+     -e TURN="curl -s -X POST https://networktraversal.googleapis.com/v1alpha/iceconfig?key=mykey" \
+     --device /dev/kvm  \
+     --publish 8554:8554/tcp \
+     --publish 5555:5555/tcp ${CONTAINER_ID}
+  ```
+
+- **During build time:** Embed the additional flag in the container itself. Everyone who launches your created container will use this flag unless it is manually overriden!
+
+  You can create the docker container with the `--extra` flag to pass in the turn configuration. For example to use a static configuration:
+
+  ```sh
+  emu-docker create canary \
+         "R" \
+         --extra  \
+         '-turncfg '\\\''printf {\"iceServers\":[{\"urls\":\"turn:\",\"username\":\"webrtc\",\"credential\":\"turnpassword\"}]}'\\\'' '
+  ```
+
+  Note the `'\\\''` to escape a single `'` and `\"` to escape `"`, as we want pass the following flag to emulator:
+
+  ```sh
+    -turncfg 'printf {"iceServers":[{"urls":"turn:","username":"webrtc","credential":"turnpassword"}]}'
+  ```
+
+  when launching the emulator.

--- a/js/turn/turn.py
+++ b/js/turn/turn.py
@@ -1,0 +1,64 @@
+# Lint as: python3
+"""A basic example of a service that can hand out temporary access to a turn server.
+
+It follows the rest api for access to turn services:
+
+https://tools.ietf.org/html/draft-uberti-rtcweb-turn-rest-00
+"""
+
+import base64
+import hmac
+import hashlib
+import time
+
+from absl import app, flags
+from flask import Flask, request, abort
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string("static_auth_secret", "supersecret", "The shared secret with the turn server.")
+flags.DEFINE_string("api_key", "supersafe", "The api key the emulator will present to retrieve turn configuration.")
+flags.DEFINE_integer("port", 8080, "The port where this service will run")
+
+api = Flask(__name__)
+
+
+@api.route("/turn/<iceserver>", methods=["GET"])
+def get_turn_cfg(iceserver):
+    """Generates a turn configuration that can be used by the emulator.
+       The turn configuration is valid for 1 hour.
+
+       See: https://tools.ietf.org/html/draft-uberti-rtcweb-turn-rest-00
+
+       Your turn server should be configured to use the same static auth secret as
+       the turn server
+
+       For example:
+
+       turnserver -n -v --log-file=stdout --static-auth-secret=supersecret \
+            -r localhost -use-auth-secret
+
+       python turn.py --static_auth_secret supersecret
+
+       Args:
+        iceserver: The turn server under your control that uses the
+                   shared secret.
+      """
+    if request.args.get("apiKey") != FLAGS.api_key:
+        abort(403, description="Invalid api key")
+
+    epoch = int(time.time()) + 3600  # You get an hour.
+    userid = "{}:{}".format(epoch, "someone")  # Username doesn't matter.
+    key = bytes(FLAGS.static_auth_secret, "UTF-8")  # Shared secret with coturn config
+    mac = hmac.digest(key, bytes(userid, "UTF-8"), hashlib.sha1)
+    credential = base64.b64encode(mac).decode()
+    return {"iceServers": [{"urls": ["turn:{}".format(iceserver)], "username": userid, "credential": credential}]}
+
+
+def main(argv):
+    if len(argv) > 1:
+        raise app.UsageError("Too many command-line arguments.")
+    api.run(host="0.0.0.0", port=FLAGS.port)
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/run-in-script-example.sh
+++ b/run-in-script-example.sh
@@ -10,8 +10,12 @@ PORT=15555
 
 # This will launch the container in the background.
 container_id=$(docker run -d \
-  -e "ADBKEY=$(cat ~/.android/adbkey)" --device /dev/kvm --publish \
-  8554:8554/tcp --publish $PORT:5555/tcp  \
+  --device /dev/kvm \
+  --publish 8554:8554/tcp \
+  --publish $PORT:5555/tcp \
+  -e TOKEN="$(cat ~/.emulator_console_auth_token)" \
+  -e ADBKEY="$(cat ~/.android/adbkey)" \
+  -e EMULATOR_PARAMS="${PARAMS}" \
   $DOCKER_IMAGE)
 
 echo "The container is running with id: $container_id"
@@ -30,10 +34,9 @@ adb wait-for-device
 
 # The device is now booting, or close to be booted
 # We just wait until the sys.boot_completed property is set to 1.
-while [ "`adb shell getprop sys.boot_completed | tr -d '\r' `" != "1" ] ;
-do
+while [ "$(adb shell getprop sys.boot_completed | tr -d '\r')" != "1" ]; do
   echo "Still waiting for boot.."
-  sleep 1;
+  sleep 1
 done
 
 echo "The device is ready"

--- a/run-with-gpu.sh
+++ b/run-with-gpu.sh
@@ -19,4 +19,13 @@ shift
 PARAMS="$@"
 # Allow display access from the container.
 xhost +si:localuser:root
-docker run --gpus all -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix  -e "TOKEN=$(cat ~/.emulator_console_auth_token)" -e "ADBKEY=$(cat ~/.android/adbkey)" -e "EMULATOR_PARAMS=-gpu host ${PARAMS}" --device /dev/kvm --publish 8554:8554/tcp --publish 5555:5555/tcp ${CONTAINER_ID}
+docker run --gpus all \
+   --device /dev/kvm \
+   --publish 8554:8554/tcp  \
+   --publish 5555:5555/tcp  \
+   -v /tmp/.X11-unix:/tmp/.X11-unix \
+   -e DISPLAY \
+   -e TOKEN="$(cat ~/.emulator_console_auth_token)" \
+   -e ADBKEY="$(cat ~/.android/adbkey)" \
+   -e EMULATOR_PARAMS="-gpu host ${PARAMS}" \
+   ${CONTAINER_ID}

--- a/run.sh
+++ b/run.sh
@@ -14,4 +14,13 @@
 CONTAINER_ID=$1
 shift
 PARAMS="$@"
-docker run -e "TOKEN=$(cat ~/.emulator_console_auth_token)" -e "ADBKEY=$(cat ~/.android/adbkey)" -e "EMULATOR_PARAMS=${PARAMS}" --device /dev/kvm --publish 8554:8554/tcp --publish 5554:5554/tcp --publish 5555:5555/tcp ${CONTAINER_ID}
+docker run \
+ --device /dev/kvm \
+ --publish 8554:8554/tcp \
+ --publish 5554:5554/tcp \
+ --publish 5555:5555/tcp \
+ -e TOKEN="$(cat ~/.emulator_console_auth_token)" \
+ -e ADBKEY="$(cat ~/.android/adbkey)" \
+ -e TURN \
+ -e EMULATOR_PARAMS="${PARAMS}"  \
+ ${CONTAINER_ID}


### PR DESCRIPTION
This updates the documentation and adds more details on how to configure
your own TURN server if needed. A TURN server is needed if the emulator
is hidden behind a VPN that does not permit UDP packets to go through.

We modify the launcher to make it easier to pass in the turn
configuration at container launch time.