### PR TITLE
Reintroduce missing exec.

### DIFF
--- a/emu/templates/launch-emulator.sh
+++ b/emu/templates/launch-emulator.sh
@@ -218,5 +218,5 @@ fi
 var_append LAUNCH_CMD -qemu -append panic=1
 
 # Kick off the emulator
-run $LAUNCH_CMD
+run exec $LAUNCH_CMD
 # All done!


### PR DESCRIPTION
Exec replaces the current running process, this makes sure that the
emulator traps the INT signal again, vs the shell.