### PR TITLE
Enable touch events in javascript example.

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -2136,7 +2136,9 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
     "android-emulator-webrtc": {
-      "version": "file:.yalc/android-emulator-webrtc",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/android-emulator-webrtc/-/android-emulator-webrtc-1.0.3.tgz",
+      "integrity": "sha512-Cnhu6ilpPaJI1tH0Md3j8+dkRY5MExnW7czCHxo2fnwQnOpYKhWzhoMJH1DCk5on9a9iOLCz0YyGhpeGXCtZuQ==",
       "requires": {
         "@material-ui/core": "^4.11.0",
         "google-protobuf": "^3.13.0",

--- a/js/package.json
+++ b/js/package.json
@@ -7,7 +7,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.56",
     "@material-ui/styles": "^4.10.0",
-    "android-emulator-webrtc": "^1.0.2",
+    "android-emulator-webrtc": "^1.0.3",
     "axios": "^0.19.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",


### PR DESCRIPTION
This bumps the version of the android emulator webrtc library to
1.0.3 which supports touch events.

Note: This requires emulator 30.1.4 or later.