### PR TITLE
Emulator version: 30.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ docker run \
   --device /dev/kvm \
   --publish 8554:8554/tcp \
   --publish 5555:5555/tcp  \
-  us-docker.pkg.dev/android-emulator-268719/images/30-google-x64:30.1.2
+  us-docker.pkg.dev/android-emulator-268719/images/30-google-x64:30.1.4
 ```
 
 This will pull down the container if it is not locally available and launch it. You can see that is
@@ -82,7 +82,7 @@ docker run -d \
   --device /dev/kvm \
   --publish 8554:8554/tcp \
   --publish 5555:5555/tcp  \
-  us-docker.pkg.dev/android-emulator-268719/images/30-google-x64:30.1.2
+  us-docker.pkg.dev/android-emulator-268719/images/30-google-x64:30.1.4
   adb connect localhost:5555
   adb wait-for-device
 
@@ -273,7 +273,7 @@ Where:
 - abi indicates the underlying CPU architecture, which is one of: _x86_, _x64_, _a32_, _a64_.
   Note that arm images are not hardware accelerated and might not be fast enough.
 
-For example: _29-playstore-x86:30.1.2_ indicates a playstore enabled system
+For example: _29-playstore-x86:30.1.4_ indicates a playstore enabled system
 image with Q running on 32-bit x86.
 
 An example invocation for publishing all Q images to google cloud repo could be:
@@ -287,7 +287,7 @@ For example:
 
 ```sh
     docker run --device /dev/kvm --publish 8554:8554/tcp --publish 5555:5555/tcp \
-    us.gcr.io/emulator-project/29-playstore-x86:30.1.2
+    us.gcr.io/emulator-project/29-playstore-x86:30.1.4
 ```
 
 ## Communicating with the emulator in the container

--- a/REGISTRY.MD
+++ b/REGISTRY.MD
@@ -32,16 +32,16 @@ Keep in mind that you will see reduced performance if you are making use of nest
 
 Here is a list of the latest images.
 
-* us-docker.pkg.dev/android-emulator-268719/images/28-playstore-x64:30.1.2
-* us-docker.pkg.dev/android-emulator-268719/images/28-playstore-x64-no-metrics:30.1.2
-* us-docker.pkg.dev/android-emulator-268719/images/29-google-x64:30.1.2
-* us-docker.pkg.dev/android-emulator-268719/images/29-google-x64-no-metrics:30.1.2
-* us-docker.pkg.dev/android-emulator-268719/images/30-google-x64:30.1.2
-* us-docker.pkg.dev/android-emulator-268719/images/30-google-x64-no-metrics:30.1.2
+* us-docker.pkg.dev/android-emulator-268719/images/28-playstore-x64:30.1.4
+* us-docker.pkg.dev/android-emulator-268719/images/28-playstore-x64-no-metrics:30.1.4
+* us-docker.pkg.dev/android-emulator-268719/images/29-google-x64:30.1.4
+* us-docker.pkg.dev/android-emulator-268719/images/29-google-x64-no-metrics:30.1.4
+* us-docker.pkg.dev/android-emulator-268719/images/30-google-x64:30.1.4
+* us-docker.pkg.dev/android-emulator-268719/images/30-google-x64-no-metrics:30.1.4
 
 For example you can now pull a container as follows:
 
-    docker pull us-docker.pkg.dev/android-emulator-268719/images/28-playstore-x64:30.1.2
+    docker pull us-docker.pkg.dev/android-emulator-268719/images/28-playstore-x64:30.1.4
 
 ### Usage
 
@@ -56,7 +56,7 @@ The following ports are available:
 
 An example invocation making the console, adb and the gRPC endpoint available:
 ```sh
-docker run -e "ADBKEY=$(cat ~/.android/adbkey)" --device /dev/kvm --publish 8554:8554/tcp --publish 5554:5554/tcp --publish 5555:5555/tcp us-docker.pkg.dev/android-emulator-268719/images/28-playstore-x64:30.1.2
+docker run -e "ADBKEY=$(cat ~/.android/adbkey)" --device /dev/kvm --publish 8554:8554/tcp --publish 5554:5554/tcp --publish 5555:5555/tcp us-docker.pkg.dev/android-emulator-268719/images/28-playstore-x64:30.1.4
 ```
 
 You might need to run `adb connect localhost:5555` to enable ADB to discover the device.


### PR DESCRIPTION
=================================

Emulator version: 30.1.4:

* us-docker.pkg.dev/android-emulator-268719/images/28-playstore-x64:30.1.4
* us-docker.pkg.dev/android-emulator-268719/images/28-playstore-x64-no-metrics:30.1.4
* us-docker.pkg.dev/android-emulator-268719/images/29-google-x64:30.1.4
* us-docker.pkg.dev/android-emulator-268719/images/29-google-x64-no-metrics:30.1.4
* us-docker.pkg.dev/android-emulator-268719/images/30-google-x64:30.1.4
* us-docker.pkg.dev/android-emulator-268719/images/30-google-x64-no-metrics:30.1.4