### PR TITLE
Make emulator screen resolution configurable

### DIFF
--- a/emu/emu_docker.py
+++ b/emu/emu_docker.py
@@ -26,7 +26,7 @@ import colorlog
 import emu
 import emu.emu_downloads_menu as emu_downloads_menu
 from emu.docker_config import DockerConfig
-from emu.docker_device import DockerDevice
+from emu.docker_device import DockerDevice, select_emulator_resolution
 from emu.cloud_build import cloud_build
 from emu.utils import mkdir_p
 
@@ -125,7 +125,8 @@ def create_docker_image_interactive(args):
     img_zip = img.download()
     emu_zip = emulator.download("linux")
     device = DockerDevice(emu_zip, img_zip, args.dest, args.gpu)
-    device.create_docker_file(args.extra, metrics)
+    emu_resolution = select_emulator_resolution()
+    device.create_docker_file(args.extra, metrics, screen_resolution=emu_resolution)
     img = device.create_container()
     if img and args.start:
         device.launch(img)

--- a/emu/templates/avd/Pixel2.avd/config.ini
+++ b/emu/templates/avd/Pixel2.avd/config.ini
@@ -29,9 +29,9 @@ runtime.network.speed=full
 vm.heapSize=512
 tag.display=Google APIs
 # Set some
-hw.lcd.density=440
-hw.lcd.height=1920
-hw.lcd.width=1080
+hw.lcd.density={{density}}
+hw.lcd.height={{height}}
+hw.lcd.width={{width}}
 # Unused
 # hw.sdCard=yes
 # sdcard.size=512M


### PR DESCRIPTION
Added emulator screen resolution configuration options in interactive mode.

<img width="623" alt="image" src="https://user-images.githubusercontent.com/20297196/102582547-cc388a00-413d-11eb-82ff-223d89838c4c.png">
