### PR TITLE
Support configurable emulator screen resolution

### DIFF
--- a/emu/emu_docker.py
+++ b/emu/emu_docker.py
@@ -26,7 +26,7 @@ import colorlog
 import emu
 import emu.emu_downloads_menu as emu_downloads_menu
 from emu.docker_config import DockerConfig
-from emu.docker_device import DockerDevice
+from emu.docker_device import DockerDevice, select_emulator_resolution
 from emu.cloud_build import cloud_build
 from emu.utils import mkdir_p
 
@@ -125,7 +125,8 @@ def create_docker_image_interactive(args):
     img_zip = img.download()
     emu_zip = emulator.download("linux")
     device = DockerDevice(emu_zip, img_zip, args.dest, args.gpu)
-    device.create_docker_file(args.extra, metrics)
+    emu_resolution = select_emulator_resolution()
+    device.create_docker_file(args.extra, metrics, screen_resolution=emu_resolution)
     img = device.create_container()
     if img and args.start:
         device.launch(img)

--- a/emu/templates/Dockerfile
+++ b/emu/templates/Dockerfile
@@ -50,13 +50,13 @@ COPY sys/ /android/sdk/system-images/android/
 # RUN --security=insecure cd /android/sdk && ./launch-emulator.sh -quit-after-boot 120
 
 # This is the console port, you usually want to keep this closed.
-EXPOSE 5554
+# EXPOSE 5554
 
 # This is the ADB port, useful.
 EXPOSE 5555
 
 # This is the gRPC port, also useful, we don't want ADB to incorrectly identify this.
-EXPOSE 8554
+# EXPOSE 8554
 
 ENV ANDROID_SDK_ROOT /android/sdk
 ENV ANDROID_AVD_HOME /android-home

--- a/emu/templates/Dockerfile
+++ b/emu/templates/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libnss3 libxcomposite1 libxcursor1 libxi6 \
     libxext6 libxfixes3 zlib1g libgl1 pulseaudio socat \
 # Enable turncfg through usage of curl
-    curl ca-certificates && \
+    curl ca-certificates iputils-ping && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/emu/templates/avd/Pixel2.avd/config.ini
+++ b/emu/templates/avd/Pixel2.avd/config.ini
@@ -29,9 +29,9 @@ runtime.network.speed=full
 vm.heapSize=512
 tag.display=Google APIs
 # Set some
-hw.lcd.density=440
-hw.lcd.height=1920
-hw.lcd.width=1080
+hw.lcd.density={{density}}
+hw.lcd.height={{height}}
+hw.lcd.width={{width}}
 # Unused
 # hw.sdCard=yes
 # sdcard.size=512M


### PR DESCRIPTION
Added emulator screen resolution configuration options in interactive mode.

<img width="623" alt="image" src="https://user-images.githubusercontent.com/20297196/102582547-cc388a00-413d-11eb-82ff-223d89838c4c.png">
