### PR TITLE
Do not give up on images where first zip is not for Linux

### DIFF
--- a/emu/emu_downloads_menu.py
+++ b/emu/emu_downloads_menu.py
@@ -269,7 +269,14 @@ class SysImgInfo(LicensedObject):
         if self.tag == "default":
             self.tag = "android"
         self.abi = details.find("abi").text
-        self.zip = pkg.find(".//url").text
+
+        # prefer a url for a Linux host in case there are multiple
+        url_element = pkg.find(".//archive[host-os='linux']/complete/url")
+        # fallback is to pick the first url
+        if url_element is None:
+            url_element = pkg.find(".//url")
+        self.zip = url_element.text
+
         self.url = "https://dl.google.com/android/repository/sys-img/%s/%s" % (self.tag, self.zip)
 
     def download(self, dest=None):


### PR DESCRIPTION
When the system image had multiple urls for multiple OSes we always
picked the first url, then later we filtered it out if it contained the
"windows" or "darwin" strings. Now we look for the "linux" url first.

"emu-docker list" shows the following additional images:

SYSIMG Q android x86_64 29 https://dl.google.com/android/repository/sys-img/android/x86_64-29_r07-linux.zip
SYSIMG Q android x86 29 https://dl.google.com/android/repository/sys-img/android/x86-29_r07-linux.zip
SYSIMG Q google_apis_playstore x86_64 29 https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-29_r08-linux.zip
SYSIMG Q google_apis_playstore x86 29 https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-29_r08-linux.zip
SYSIMG R google_apis_playstore x86_64 30 https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86_64-30_r10-linux.zip
SYSIMG R google_apis_playstore x86 30 https://dl.google.com/android/repository/sys-img/google_apis_playstore/x86-30_r09-linux.zip