### PR TITLE
Update android-emulator-webrtc package.

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -11,7 +11,7 @@
         "@material-ui/icons": "^4.11.2",
         "@material-ui/lab": "^4.0.0-alpha.57",
         "@material-ui/styles": "^4.11.3",
-        "android-emulator-webrtc": "1.0.8",
+        "android-emulator-webrtc": "^1.0.10",
         "axios": "^0.21.1",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
@@ -2585,9 +2585,9 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
     "node_modules/android-emulator-webrtc": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/android-emulator-webrtc/-/android-emulator-webrtc-1.0.8.tgz",
-      "integrity": "sha512-DDALVrwCmfMWCoi1sulk1SetYZ1myMBJX6Y4332t8yBMUmb/pkPykc5s5UzJwrMRfgyuYDmB03kRAse8LQ3Gyw==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/android-emulator-webrtc/-/android-emulator-webrtc-1.0.10.tgz",
+      "integrity": "sha512-E+1ZeklhXDktEru6lHWh3EOqRTkxE2x5KA25w8xzNe7zEqFv6CkMK267WoSL96UUbBiTccaKZ8wSj2stou6sgg==",
       "dependencies": {
         "@material-ui/core": "^4.11.3",
         "google-protobuf": "^3.14.0",
@@ -19149,9 +19149,9 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM="
     },
     "android-emulator-webrtc": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/android-emulator-webrtc/-/android-emulator-webrtc-1.0.8.tgz",
-      "integrity": "sha512-DDALVrwCmfMWCoi1sulk1SetYZ1myMBJX6Y4332t8yBMUmb/pkPykc5s5UzJwrMRfgyuYDmB03kRAse8LQ3Gyw==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/android-emulator-webrtc/-/android-emulator-webrtc-1.0.10.tgz",
+      "integrity": "sha512-E+1ZeklhXDktEru6lHWh3EOqRTkxE2x5KA25w8xzNe7zEqFv6CkMK267WoSL96UUbBiTccaKZ8wSj2stou6sgg==",
       "requires": {
         "@material-ui/core": "^4.11.3",
         "google-protobuf": "^3.14.0",

--- a/js/package.json
+++ b/js/package.json
@@ -7,7 +7,7 @@
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.57",
     "@material-ui/styles": "^4.11.3",
-    "android-emulator-webrtc": "^1.0.8",
+    "android-emulator-webrtc": "^1.0.10",
     "axios": "^0.21.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",


### PR DESCRIPTION
We update to a newew package version that contains a series of
concurrency fixes that can arise with emulator builds <7118781

Fixes: #210