### PR TITLE
Update cloud-init for multi emulator deployment

### DIFF
--- a/cloud-init/README.MD
+++ b/cloud-init/README.MD
@@ -16,8 +16,8 @@ Follow the steps to for your cloud provider to create an image with:
 
 - nested virtualization
 - docker
-- and cloud-init
-- tmpfs with at least 8gb at emulator launch.
+- cloud-init
+- tmpfs with at least 8gb per emulator that is launched.
 
 # Overview
 
@@ -25,11 +25,14 @@ The cloud-init file will launch a systemd service that will pull a public docker
 
 Most notable are:
 
-- **GRPC_PORT**: The port where the gRPC service will be running. Defaults to 8554
-- **ADB_PORT**: The port where ADB will be available. Defaults to 5555
+- **GRPC_PORT**: The port where the first instance of the gRPC service will be running. Defaults to 8554. The second instance will be available at 8555, etc.
+- **ADB_PORT**: The port where the first instance of the ADB will be available. Defaults to 5555. The second instance will be available at 5556, etc.
+- **INSTNCE_COUNT**: The number of emulators to start, defaults to 1. By default the emulator uses 4 vcpus, and 12gb per instance (4 gb memory, 8 gb tmpfs).
 - **TURN**: Configuration used to start turn server.
 - **ADBKEY**: The private adb key that will be embedded in the emulator.
-- **EMULATOR_IMG**: The url to a public docker image that will be launched. Defaults to `us-docker.pkg.dev/android-emulator-268719/images/30-google-x64:30.3.4`
+- **EMULATOR_IMG**: The url to a public docker image that will be launched. Defaults to `us-docker.pkg.dev/android-emulator-268719/images/30-google-x64:latest`
+- **AVD_CONFIG**: Additional avd configuration that should be added to the configuration
+- **EMULATOR_PARAMS**: Additional emulator parameters that should be added.
 
 First make sure the [cloud-init](cloud-init) file contains all the proper definitions needed for launch.
 
@@ -37,10 +40,13 @@ If you are running in gce you have the option the specify the properties above a
 
 - emulator_grpc_port maps to GRPC_PORT
 - emulator_adb_port maps to ADB_PORT
-- emulator_image maps to EMULATOR_IMG
+- emulator_image maps to $IMAGE
 - emulator_adbkey maps to ADBKEY
 - emulator_turn maps to TURN
+- emulator_instance_count maps to $INSTANCE_COUNT
 
+Emulators are launched using the aemu.service systemd service. This service will start a series of emulators that, named aemu_1, aemu_2, etc.
+Keep in mind that it can take a while to pull and launch the emulator, esp. if you are running more than one emulator.
 # Lauching the instance
 
 For example if you created a gce image with nested virtualization you can launch an instance as follows:
@@ -54,7 +60,7 @@ For example if you created a gce image with nested virtualization you can launch
               --machine-type n1-highcpu-32 \
               --tags=http-server,https-server \
               --metadata-from-file user-data=cloud-init \
-              --emulator_adbkey="$(cat ~/.android/adbkey)",emulator_adb_port=80,emulator_grpc_port=443
+              --metadata=emulator_adbkey="$(cat ~/.android/adbkey)",emulator_adb_port=80,emulator_grpc_port=443
 ```
 
 Next you can connect to the emulator from your local machine as follows:
@@ -65,3 +71,48 @@ adb connect $IP:80
 ```
 
 Your device should now be available for access over adb.
+
+## Building a container optimized os (cos) with kvm enabled.
+
+Google provides a container optimized os for running docker images. Unfortunately the base images do not expose the
+kvm kernels and cannot be used directly for the android emulator. In order to run them on gce you will have to
+build your own cos image, with KVM enabled.
+
+- First obtain the [cos source](https://cloud.google.com/container-optimized-os/docs/how-to/building-from-open-source#obtaining_the_source_code)
+- Next apply the following changes:
+
+```
+diff --git a/project-lakitu/sys-kernel/lakitu-kernel-5_4/files/base.config b/project-lakitu/sys-kernel/lakitu-kernel-5_4/files/base.config
+index e13a9e170e..a31b2b73db 100644
+--- a/project-lakitu/sys-kernel/lakitu-kernel-5_4/files/base.config
++++ b/project-lakitu/sys-kernel/lakitu-kernel-5_4/files/base.config
+@@ -609,7 +609,13 @@ CONFIG_EFI_EARLYCON=y
+
+ CONFIG_HAVE_KVM=y
+ CONFIG_VIRTUALIZATION=y
+-# CONFIG_KVM is not set
++# is not set
++CONFIG_KVM=m
++CONFIG_KVM_INTEL=m
++CONFIG_KVM_MMU_AUDIT=m
++CONFIG_KVM_AMD=m
++CONFIG_VHOST_NET=m
++CONFIG_VHOST_VSOCK=m
+ # CONFIG_VHOST_NET is not set
+ # CONFIG_VHOST_SCSI is not set
+ # CONFIG_VHOST_VSOCK is not set
+```
+
+in ./src/overlays
+
+- Next follow the steps to build to [os](https://cloud.google.com/container-optimized-os/docs/how-to/building-from-open-source#building_a_image)
+- Follow the steps to import the build into a system image in [gce](https://cloud.google.com/container-optimized-os/docs/how-to/building-from-open-source#running_on)
+
+Next we need to create an image with nested virtualizaton enabled. In the steps below we assume that you imported the image as `emu-dev-cos-base` is `us-west1-b`:
+
+    gcloud compute disks create cos-dev-nested-disk --image emu-dev-cos-base  --zone us-west1-b
+    gcloud compute images create cos-dev-nested --source-disk cos-dev-nested-disk --source-disk-zone us-west1-b --licenses "https://www.googleapis.com/compute/v1/projects/vm-options/global/licenses/enable-vmx"
+
+Congratulations! You have created a `cos-dev-nested` image with virtualization enabled that can be used in the examples above.
+
+

--- a/cloud-init/cloud-init
+++ b/cloud-init/cloud-init
@@ -23,6 +23,7 @@ write_files:
   content: |
     GRPC_PORT=8554
     ADB_PORT=5555
+    # Replace with your own turn command (Be careful of escaping ")
     TURN=
     # Replace with your own accessible image.
     EMULATOR_IMG=us-docker.pkg.dev/android-emulator-268719/images/30-google-x64:30.3.4

--- a/cloud-init/cloud-init
+++ b/cloud-init/cloud-init
@@ -21,12 +21,17 @@ write_files:
   permissions: 0644
   owner: root
   content: |
+    INSTANCE_COUNT=1
     GRPC_PORT=8554
     ADB_PORT=5555
     # Replace with your own turn command (Be careful of escaping ")
     TURN=
+    # Additional emulator parameters
+    EMULATOR_PARAMS=
+    # Additional avd config
+    AVD_CONFIG=
     # Replace with your own accessible image.
-    EMULATOR_IMG=us-docker.pkg.dev/android-emulator-268719/images/30-google-x64:30.3.4
+    IMAGE=us-docker.pkg.dev/android-emulator-268719/images/30-google-x64:latest
     # Replace with your own private adb key
     ADBKEY="-----BEGIN PRIVATE KEY----- \
       MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQC5k0vjoBVDYb/i \
@@ -72,10 +77,44 @@ write_files:
     }
     override_metadata emulator_grpc_port GRPC_PORT
     override_metadata emulator_adb_port ADB_PORT
-    override_metadata emulator_image EMULATOR_IMG
+    override_metadata emulator_image IMAGE
     override_metadata emulator_adbkey ADBKEY
     override_metadata emulator_turn TURN
-    override_metadata emulator_img EMULATOR_IMG
+    override_metadata emulator_avd_config AVD_CONFIG
+    override_metadata emulator_instance_count INSTANCE_COUNT
+    override_metadata emulator_emulator_params EMULATOR_PARAMS
+
+- path: /usr/local/bin/launch_containers
+  permissions: 0755
+  owner: root
+  content: |
+    #!/bin/sh
+    CONTAINER=
+    for IDX in $(seq 1 $1); do
+        LGRPC_PORT=$(($GRPC_PORT + $IDX - 1))
+        LADB_PORT=$(($ADB_PORT + $IDX - 1))
+        NAME=aemu_$IDX
+        /usr/bin/docker run --rm -d \
+            --name=$NAME \
+            --device /dev/kvm \
+            -e ADBKEY \
+            -e TURN \
+            -e EMULATOR_PARAMS \
+            -e AVD_CONFIG \
+            -p ${LGRPC_PORT}:8554/tcp \
+            -p ${LADB_PORT}:5555/tcp \
+            --mount type=tmpfs,destination=/data \
+            ${IMAGE}
+        CONTAINER="${CONTAINER} ${NAME}"
+    done
+    /usr/bin/docker wait $CONTAINER
+
+- path: /usr/local/bin/stop_containers
+  permissions: 0755
+  owner: root
+  content: |
+    #!/bin/sh
+    /usr/bin/docker container stop $(/usr/bin/docker container ls -q --filter name="aemu")
 
 - path: /etc/systemd/system/aemu.service
   permissions: 0644
@@ -87,18 +126,8 @@ write_files:
     After=docker.service
     [Service]
     EnvironmentFile=/run/metadata/aemu
-    ExecStart=/usr/bin/docker run --rm \
-                              --name=my_aemu \
-                              --device /dev/kvm \
-                              -e ADBKEY \
-                              -e TURN \
-                              --publish ${GRPC_PORT}:8554/tcp \
-                              --publish ${ADB_PORT}:5555/tcp \
-                              --mount type=tmpfs,destination=/data \
-                              ${EMULATOR_IMG}
-    ExecStop=/usr/bin/docker stop my_aemu
-    ExecStopPost=/usr/bin/docker rm my_aemu
-
+    ExecStart=/usr/local/bin/launch_containers $INSTANCE_COUNT
+    ExecStop=/usr/local/bin/stop_containers
 runcmd:
 - chown root:kvm /dev/kvm
 - chmod 0660 /dev/kvm

--- a/emu/docker_device.py
+++ b/emu/docker_device.py
@@ -122,8 +122,10 @@ class DockerDevice(object):
             tag = self.emulator.build_id()
 
         self.tag = "{}:{}".format(repo, tag)
+        self.latest = "{}:latest".format(repo)
         if not self.TAG_REGEX.match(self.tag):
             raise Exception("The resulting tag: {} is not a valid docker tag.", self.tag)
+
 
         # The following are only set after creating/launching.
         self.container = None
@@ -193,7 +195,7 @@ class DockerDevice(object):
         return identity
 
     def create_cloud_build_step(self):
-        return {"name": "gcr.io/cloud-builders/docker", "args": ["build", "-t", self.tag, os.path.basename(self.dest)]}
+        return {"name": "gcr.io/cloud-builders/docker", "args": ["build", "-t", self.tag, "-t", self.latest, os.path.basename(self.dest)]}
 
     def launch(self, image_sha, port=5555):
         """Launches the container with the given sha, publishing abd on port, and grpc on port 8554

--- a/emu/emu_docker.py
+++ b/emu/emu_docker.py
@@ -258,6 +258,11 @@ def main():
     )
     dist_parser.add_argument("--git", action="store_true", help="Create a git commit, and push to destination.")
     dist_parser.add_argument(
+        "emuzip",
+        help="Zipfile containing the a publicly released emulator, or (canary|stable|[0-9]+) to use the latest canary, stable, or build id of the emulator to use. "
+        "Keep in mind that using a build id can result in downloading an untested pre-release emulator build from the android ci server.",
+    )
+    dist_parser.add_argument(
         "img",
         default="P google_apis_playstore x86_64|Q google_apis_playstore x86_64",
         help="A regexp matching the image to retrieve. "

--- a/emu/emu_downloads_menu.py
+++ b/emu/emu_downloads_menu.py
@@ -160,7 +160,7 @@ class AndroidReleaseZip(object):
 
     def build_id(self):
         """The build id, or revision of build id is not available."""
-        if "Pgk.BuildId" in self.props:
+        if "Pkg.BuildId" in self.props:
             return self.props.get("Pkg.BuildId")
         return self.revision()
 

--- a/emu/templates/launch-emulator.sh
+++ b/emu/templates/launch-emulator.sh
@@ -183,6 +183,7 @@ initialize_data_part() {
   if  is_mounted /data; then
     run cp -fr /android-home/ /data
     ln -sf /data/android-home /root/.android/avd
+    echo "path=/root/.android/avd/Pixel2.avd" > /root/.android/avd/Pixel2.ini
   else
     ln -sf /android-home /root/.android/avd
   fi

--- a/tests/e2e/test_cloud_build.py
+++ b/tests/e2e/test_cloud_build.py
@@ -26,7 +26,7 @@ from emu.cloud_build import cloud_build
 from utils import TempDir
 
 
-Arguments = collections.namedtuple("Args", "img, dest, repo, git")
+Arguments = collections.namedtuple("Args", "emuzip, img, dest, repo, git")
 
 
 @pytest.mark.slow
@@ -35,15 +35,13 @@ def test_build_container():
     assert docker.from_env().ping()
     # Make sure we accept all licenses,
     with TempDir() as tmp:
-        args = Arguments("(P google_apis_playstore x86_64)|(Q google_apis x86_64)", tmp, "us.gcr.io/emu-dev-tst", False)
+        args = Arguments("canary", "Q google_apis x86_64", tmp, "us.gcr.io/emu-dev-tst", False)
         cloud_build(args)
         expected_files = [
             "cloudbuild.yaml",
             "README.MD",
-            "p-playstore-x64",
-            "p-playstore-x64-no-metrics",
-            "q-google-x64",
-            "q-google-x64-no-metrics",
+            "29-google-x64",
+            "29-google-x64-no-metrics",
         ]
         for fname in expected_files:
             assert os.path.exists(os.path.join(tmp, fname))

--- a/tests/e2e/test_launch_containers.py
+++ b/tests/e2e/test_launch_containers.py
@@ -36,7 +36,7 @@ Arguments = collections.namedtuple("Args", "emuzip, imgzip, dest, tag, start, ex
 
 @pytest.mark.slow
 @pytest.mark.e2e
-@pytest.mark.parametrize('channel, img, gpu', [('all', 'Q google_apis x86_64', True), ('stable', 'P android x86_64', False)])
+@pytest.mark.parametrize('channel, img, gpu', [('all', 'Q google_apis x86_64', True)])
 def test_build_container(channel, img, gpu):
     assert docker.from_env().ping()
     # Make sure we accept all licenses,
@@ -53,7 +53,7 @@ def test_build_container(channel, img, gpu):
 @pytest.mark.slow
 @pytest.mark.e2e
 @pytest.mark.linux
-@pytest.mark.parametrize('channel, img, gpu', [('all', 'Q google_apis x86_64', True), ('stable', 'P android x86_64', False)])
+@pytest.mark.parametrize('channel, img, gpu', [('stable', 'P android x86_64', False)])
 def test_run_container(channel, img, gpu):
     assert docker.from_env().ping()
     with TempDir() as tmp:


### PR DESCRIPTION
This updates the cloud-init scripts to support multiple emulators to run side by side.