### PR TITLE
setup stretch-slim base image to allow installing openjdk

### DIFF
--- a/emu/docker_device.py
+++ b/emu/docker_device.py
@@ -103,7 +103,12 @@ class DockerDevice(object):
         "FROM nvidia/opengl:1.0-glvnd-runtime-ubuntu18.04 AS emulator\n"
         + "ENV NVIDIA_DRIVER_CAPABILITIES ${NVIDIA_DRIVER_CAPABILITIES},display"
     )
-    DEFAULT_BASE_IMG = "FROM debian:stretch-slim AS emulator"
+    DEFAULT_BASE_IMG = (
+        "FROM debian:stretch-slim AS emulator\n"
+        + "RUN "
+        + "printf 'path-exclude=/usr/share/locale/*\npath-exclude=/usr/share/man/*\npath-exclude=/usr/share/doc/*\npath-include=/usr/share/doc/*/copyright\n'"
+        + " > /etc/dpkg/dpkg.cfg.d/01_nodoc && mkdir -p /usr/share/man/man1"
+    )
 
     def __init__(self, emulator, sysimg, dest_dir, gpu=False, repo="", tag="", name=""):
 
@@ -125,7 +130,6 @@ class DockerDevice(object):
         self.latest = "{}:latest".format(repo)
         if not self.TAG_REGEX.match(self.tag):
             raise Exception("The resulting tag: {} is not a valid docker tag.", self.tag)
-
 
         # The following are only set after creating/launching.
         self.container = None


### PR DESCRIPTION
The stretch-slim base image removes the man pages, docs, locales, etc. Some package install processes will fail if the dirs are not present, like /usr/share/man/man1.  This includes `default-jdk-headless`, which someone would install if they wanted to run a gradle build in the Docker image before starting the emulator.

The mkdir hack comes from:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199

Here's an example of running a build in this image:
https://gitlab.com/eighthave/ci-images-emulator-kvm/-/jobs/1052060212