### PR TITLE
Set ANDROID_AVD_HOME so the cleanup works

### DIFF
--- a/emu/templates/launch-emulator.sh
+++ b/emu/templates/launch-emulator.sh
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 VERBOSE=3
+ANDROID_AVD_HOME=/root/.android/avd
 
 # Return the value of a given named variable.
 # $1: variable name
@@ -182,10 +183,10 @@ initialize_data_part() {
   # and if so, we will use that as our avd directory.
   if  is_mounted /data; then
     run cp -fr /android-home/ /data
-    ln -sf /data/android-home /root/.android/avd
-    echo "path=/root/.android/avd/Pixel2.avd" > /root/.android/avd/Pixel2.ini
+    ln -sf /data/android-home ${ANDROID_AVD_HOME}
+    echo "path=${ANDROID_AVD_HOME}/Pixel2.avd" > ${ANDROID_AVD_HOME}/Pixel2.ini
   else
-    ln -sf /android-home /root/.android/avd
+    ln -sf /android-home ${ANDROID_AVD_HOME}
   fi
 }
 


### PR DESCRIPTION
We can therefore bind mount /data as a persistent volume without errors