### PR TITLE
Add support to Android 12 (S) images

### DIFF
--- a/emu/emu_downloads_menu.py
+++ b/emu/emu_downloads_menu.py
@@ -55,6 +55,8 @@ API_LETTER_MAPPING = {
     "28": "P",
     "29": "Q",
     "30": "R",
+    "31": "S",
+    "32": "S",
 }
 
 # Older versions might not work as expected.

--- a/emu/templates/Dockerfile.system_image
+++ b/emu/templates/Dockerfile.system_image
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied_
 # See the License for the specific language governing permissions and
 # limitations under the License_
-FROM alpine AS unzipper
+FROM alpine:3.3 AS unzipper
 RUN apk add --update unzip
 
 # Barely changes


### PR DESCRIPTION
Since the current version didn't support the newest versions of emulators (using interactive mode), I've added a line to add the support in emu_downloads_menu.py.
However, I have trouble concerning the unzipping of the image through the default Docker system image template. Apparently, there is some bug in the latest unzip version (6.0-r9) to detect zip bombs. This version was considering the Android 12 system images' zips as possibles zip bombs. I fixed it by downgrading the alpine version to v3.3 considering it uses the unzip version 6.0-r1. I've not tested using some new alpine versions rather than the latest one to verify in which version of alpine and unzip this issue started to happen.
Everything seems to be working though.