### PR TITLE
Directly call exec to launch the emulator

### DIFF
--- a/emu/templates/launch-emulator.sh
+++ b/emu/templates/launch-emulator.sh
@@ -240,5 +240,5 @@ fi
 var_append LAUNCH_CMD -qemu -append panic=1
 
 # Kick off the emulator
-run exec $LAUNCH_CMD
+exec $LAUNCH_CMD
 # All done!


### PR DESCRIPTION
Calling the 'run' function inside the launch-emulator.sh script causes
issue with parameter quoting, which in turn breaks the usage of the
`TURN` environment variable.

We now directly call exec, vs the run function.