### PR TITLE
Failure to launch

### DIFF
--- a/emu/templates/launch-emulator.sh
+++ b/emu/templates/launch-emulator.sh
@@ -195,8 +195,8 @@ initialize_data_part() {
 
 # Let us log the emulator,script and image version.
 log_version_info
-initialize_data_part
 clean_up
+initialize_data_part
 install_console_tokens
 install_adb_keys
 install_grpc_certs

--- a/emu/templates/launch-emulator.sh
+++ b/emu/templates/launch-emulator.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2019 - The Android Open Source Project
 #
@@ -57,11 +57,8 @@ var_append () {
     local _var_append_varname
     _var_append_varname=$1
     shift
-    if test "$(var_value $_var_append_varname)"; then
-        eval $_var_append_varname=\$$_var_append_varname\'\ $(_var_quote_value "$*")\'
-    else
-        eval $_var_append_varname=\'$(_var_quote_value "$*")\'
-    fi
+
+    eval $_var_append_varname+=\('"$@"'\)
 }
 
 is_mounted () {
@@ -233,12 +230,12 @@ if [ ! -z "${EMULATOR_PARAMS}" ]; then
 fi
 
 if [ ! -z "${TURN}" ]; then
-  var_append LAUNCH_CMD -turncfg \'${TURN}\'
+  var_append LAUNCH_CMD -turncfg "${TURN}"
 fi
 
 # Add qemu specific parameters
 var_append LAUNCH_CMD -qemu -append panic=1
 
 # Kick off the emulator
-exec $LAUNCH_CMD
+exec "${LAUNCH_CMD[@]}"
 # All done!


### PR DESCRIPTION
This PR fixes 2 problems I ran into when trying to run this project.  

The first one is a simple order of operations.  /root/.android doesn't exist in the container until clean_up is called. However, initialize_data_part tries place a softlink in that directory, resulting in this error:

```
emulator_1     | ERROR   | Unknown AVD name [Pixel2], use -list-avds to see valid list.
emulator_1     | ERROR   | HOME is defined but there is no file Pixel2.ini in $HOME/.android/avd
emulator_1     | ERROR   | (Note: Directories are searched in the order $ANDROID_AVD_HOME, $ANDROID_SDK_HOME/avd and $HOME/.android/avd)
```

Switching the order of clean_up then initialize_data_part solves this.

The second one was more frustrating.  Using the examples to utilize TURN was failing because var_append wasn't handling 'printf JSON_BLOB' and instead exec was just receiving 'printf':

```
echo $TURN
printf {"iceServers":[{"urls":"turn:","username":"webrtc","credential":"turnpassword"}]}
```
```
emulator/emulator -avd Pixel2 -ports 5556,5557 -grpc 8554 -no-window -skip-adb-auth -no-snapshot-save -wipe-data -no-boot-anim -shell-serial file:/tmp/android-unknown/kernel.log -logcat *:V -logcat-output /tmp/android-unknown/logcat.log -logcat *:V -feature AllowSnapshotMigration -gpu swiftshader_indirect -shell-serial file:/tmp/android-unknown/kernel.log -logcat-output /tmp/android-unknown/logcat.log -turncfg 'printf {"iceServers":[{"urls":"turn:","username":"webrtc","credential":"turnpassword"}]}' -qemu -append panic=1
INFO    | Android emulator version 32.1.11.0 (build_id 9536276) (CL:N/A)
INFO    | Found systemPath /android/sdk/system-images/android/x86_64/
INFO    | Crashreporting disabled, not reporting crashes.
INFO    | Duplicate loglines will be removed, if you wish to see each indiviudal line launch with the -log-nofilter flag.
invalid command-line parameter: {"iceServers":[{"urls":"turn:","username":"webrtc","credential":"turnpassword"}]}'.
```
Fixed this by switching to bash to allow bash arrays, changing var_append to construct an array, and switching the call to exec to use the array.

I just submitted a CLA - hopefully that gets processed in time to accept this PR.


Thanks!
John Payne
Procella Technologies




