### PR TITLE
[emu] add support for google_atd

### DIFF
--- a/emu/android_release_zip.py
+++ b/emu/android_release_zip.py
@@ -114,6 +114,7 @@ class SystemImageReleaseZip(AndroidReleaseZip):
         "android": "aosp",
         "google_apis": "google",
         "google_apis_playstore": "playstore",
+        "google_atd": "google_atd",
         "google_ndk_playstore": "ndk_playstore",
         "android-tv": "tv",
     }

--- a/emu/emu_downloads_menu.py
+++ b/emu/emu_downloads_menu.py
@@ -31,6 +31,7 @@ SYSIMG_REPOS = [
     "https://dl.google.com/android/repository/sys-img/android/sys-img2-1.xml",
     "https://dl.google.com/android/repository/sys-img/google_apis/sys-img2-1.xml",
     "https://dl.google.com/android/repository/sys-img/google_apis_playstore/sys-img2-1.xml",
+    "https://dl.google.com/android/repository/sys-img/google_atd/sys-img2-1.xml",
     "https://dl.google.com/android/repository/sys-img/android-tv/sys-img2-1.xml",
 ]
 
@@ -118,6 +119,7 @@ class SysImgInfo(LicensedObject):
         "android": "aosp",
         "google_apis": "google",
         "google_apis_playstore": "playstore",
+        "google_atd": "google_atd",
         "google_ndk_playstore": "ndk_playstore",
         "android-tv": "tv",
     }


### PR DESCRIPTION
Adding support to download and use `google_atd` system images:
```
(venv) ➜  android-emulator-container-scripts git:(master) ✗ emu-docker list | grep google_atd
SYSIMG R google_atd x86 30 https://dl.google.com/android/repository/sys-img/google_atd/x86-30_r01.zip
SYSIMG S google_atd x86_64 31 https://dl.google.com/android/repository/sys-img/google_atd/x86_64-31_r01.zip
```