### PR TITLE
Honor DOCKER_HOST in get_api_client()

### DIFF
--- a/emu/containers/docker_container.py
+++ b/emu/containers/docker_container.py
@@ -33,8 +33,10 @@ class DockerContainer:
         return docker.from_env()
 
     def get_api_client(self) -> docker.APIClient:
+        # Honor DOCKER_HOST so Docker Desktop, podman, and other rootless or
+        # non-default daemon sockets work without symlinking /var/run/docker.sock.
         try:
-            api_client = docker.APIClient()
+            api_client = docker.APIClient(base_url=os.environ.get("DOCKER_HOST"))
             logging.info(api_client.version())
             return api_client
         except Exception as _err:
@@ -42,7 +44,7 @@ class DockerContainer:
                 "Failed to create default client, trying domain socket.", exc_info=True
             )
 
-        api_client = docker.APIClient(base_url="unix://var/run/docker.sock")
+        api_client = docker.APIClient(base_url="unix:///var/run/docker.sock")
         logging.info(api_client.version())
         return api_client
 


### PR DESCRIPTION
## Summary
- Pass `DOCKER_HOST` through to `docker.APIClient(base_url=...)`. The docker-py SDK's `APIClient()` constructor reads no env vars (only `from_env()` does), so emu-docker silently falls back to `/var/run/docker.sock` on every machine. That's broken for Docker Desktop, podman, and anyone whose daemon socket is elsewhere.
- Also corrects the malformed fallback URI `unix://var/run/docker.sock` → `unix:///var/run/docker.sock` (canonical 3-slash form).

## Symptom without this fix
```
docker.errors.DockerException: Error while fetching server API version:
('Connection aborted.', PermissionError(13, 'Permission denied'))
```

## Test plan
- [x] With `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock` (rootless podman): `emu-docker create <emu.zip> <sysimg.zip> --start` builds the image, boots Android 9 (API 28) in the container, `adb connect` succeeds, `sys.boot_completed=1`.
- [x] Without `DOCKER_HOST` set: behavior unchanged — `docker.APIClient(base_url=None)` is equivalent to `docker.APIClient()`.

## Related
- #124 — earlier report of the same surface error (`PermissionError [Errno 13]` on the docker socket). Closed at the time as a user/permissions issue, but the same fix would have unblocked any reporter on a non-default socket (Docker Desktop, podman).