### PR TITLE
Fix two typos in emu/containers/docker_container.py

### DIFF
--- a/emu/containers/docker_container.py
+++ b/emu/containers/docker_container.py
@@ -67,7 +67,7 @@ class DockerContainer:
             logging.warning("docker push %s", image)
 
     def launch(self, port_map) -> Image:
-        """Launches the container with the given sha, publishing abd on port, and gRPC on port 8554
+        """Launches the container with the given sha, publishing adb on port 5555, and gRPC on port 8554
 
         Returns the container.
         """
@@ -200,7 +200,7 @@ class DockerContainer:
     def available(self):
         """True if this container image is locally available."""
         if self.docker_image():
-            logging.info("%s is avaliable", self.docker_image().tags)
+            logging.info("%s is available", self.docker_image().tags)
             return True
         return False
 


### PR DESCRIPTION
Two trivial typo fixes in `emu/containers/docker_container.py`:

- `launch()` docstring: `abd` → `adb` (also include the port number for parity with the `gRPC on port 8554` half of the sentence).
- `available()` log message: `avaliable` → `available`.

Originally proposed by @binderjens in #350. The README half of that PR was already addressed by #390 (danishprakash), so cherry-picking just the two typos here. Closing #350 once this lands.

## Test plan
- [x] No behavior change beyond the log-message string and a docstring update.
- [x] All 35 tests under `tests/` (excluding e2e) still pass.