### PR TITLE
README: point the Azure nested-virt link at the right Microsoft doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ following requirements:
   - AWS provides [bare
     metal](https://aws.amazon.com/about-aws/whats-new/2019/02/introducing-five-new-amazon-ec2-bare-metal-instances/)
     instances that provide access to KVM.
-  - Azure: Follow these
-    [instructions](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/nested-virtualization)
-    to enable nested virtualization.
+  - Azure: pick a [VM size that supports nested virtualization](https://learn.microsoft.com/en-us/azure/virtual-machines/acu)
+    (the `acu` table flags supported families). KVM is then available inside the VM.
   - GCE: Follow these
     [instructions](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances)
     to enable nested virtualization.


### PR DESCRIPTION
The previous link (`docs.microsoft.com/.../windows/nested-virtualization`) is the Windows feature page; the actual gating concern for running the emulator container on Azure is picking a VM size whose family supports nested virtualization. Microsoft's Azure Compute Units table flags this per family, so point users there instead.

Closes #285.