### PR TITLE
launch-emulator.sh: stop hardcoding -gpu swiftshader_indirect

### DIFF
--- a/emu/templates/launch-emulator.sh
+++ b/emu/templates/launch-emulator.sh
@@ -181,7 +181,7 @@ LAUNCH_CMD+=("-skip-adb-auth" "-no-snapshot-save" "-wipe-data" "-no-boot-anim")
 LAUNCH_CMD+=("-shell-serial" "file:/tmp/android-unknown/kernel.log")
 LAUNCH_CMD+=("-logcat" "*:V")
 LAUNCH_CMD+=("-feature" "AllowSnapshotMigration")
-LAUNCH_CMD+=("-gpu" "swiftshader_indirect" {{extra}})
+LAUNCH_CMD+=({{extra}})
 
 if [ ! -z "${EMULATOR_PARAMS}" ]; then
   LAUNCH_CMD+=($EMULATOR_PARAMS)


### PR DESCRIPTION
The launcher appended `-gpu swiftshader_indirect` to every emulator invocation, which silently overrode the AVD's own `hw.gpu.mode = auto` (the template default in `Pixel2.avd/config.ini`). The intent of `auto` is to let the emulator pick the best available renderer; the launcher's pin defeated that.

## Change
One line in `emu/templates/launch-emulator.sh`:

```diff
-LAUNCH_CMD+=("-gpu" "swiftshader_indirect" {{extra}})
+LAUNCH_CMD+=({{extra}})
```

## Behavior delta on a software-only container
| | before | after |
|---|---|---|
| `gpu_mode_requested` (verbose log) | `swiftshader_indirect` | `lavapipe` (chosen by `auto`) |
| Vulkan path | SwiftShader (Subzero) | Mesa **lavapipe** |
| GLES path | SwiftShader Indirect | **swangle** (ANGLE on swrast) |

Both stacks are software renderers; lavapipe is generally faster and supports a richer feature set than SwiftShader.

## Escape hatches preserved
Anyone who specifically wants the prior pin can keep it via any of:
- `--extra "-gpu" "swiftshader_indirect"` at `emu-docker create` time (baked into the image)
- `hw.gpu.mode = swiftshader_indirect` in the AVD `config.ini`
- `EMULATOR_PARAMS='-gpu swiftshader_indirect'` at `docker run` time

Hardware passthrough (`-gpu host` with `--device nvidia.com/gpu=all` or `/dev/dri/*`) is unaffected — the launcher never set `host` mode on its own.

## Test plan
- [x] Patched launcher inside a freshly built API 37 google_apis_playstore ps16k container; started with no `-gpu` in `EMULATOR_PARAMS`.
- [x] `docker logs` shows `gpu_mode_requested: lavapipe` → `vulkan_mode_selected:lavapipe gles_mode_selected:swangle` → `setCurrentRenderer: swangle lavapipe gles:Angle Indirect vulkan:Lavapipe`.
- [x] `sys.boot_completed = 1`, `adb shell` works.
- [x] All 35 tests under `tests/` (excluding e2e) still pass.
