### PR TITLE
templates: rename the AVD from Pixel2 to MediumPhone

### DIFF
--- a/emu/containers/emulator_container.py
+++ b/emu/containers/emulator_container.py
@@ -76,8 +76,8 @@ class EmulatorContainer(DockerContainer):
         self.clean(dest)
 
         writer = TemplateWriter(dest)
-        writer.write_template("avd/Pixel2.ini", self.props)
-        writer.write_template("avd/Pixel2.avd/config.ini", self.props)
+        writer.write_template("avd/MediumPhone.ini", self.props)
+        writer.write_template("avd/MediumPhone.avd/config.ini", self.props)
 
         # Include a README.MD message.
         writer.write_template(

--- a/emu/templates/avd/MediumPhone.avd/config.ini
+++ b/emu/templates/avd/MediumPhone.avd/config.ini
@@ -1,9 +1,8 @@
-AvdId=Pixel2
+AvdId=MediumPhone
 PlayStore.enabled={{playstore}}
-avd.ini.displayname=Pixel2
+avd.ini.displayname=MediumPhone
 avd.ini.encoding=UTF-8
-# Real Pixel2 ships with 32GB
-disk.dataPartition.size=512MB
+disk.dataPartition.size=10G
 fastboot.forceColdBoot=no
 hw.accelerometer=yes
 hw.audioInput=yes
@@ -28,10 +27,8 @@ runtime.network.latency=none
 runtime.network.speed=full
 vm.heapSize=512
 tag.display=Google APIs
-# Note: these are the ones that usually vary from device to device
-# for example a Pixel 6 will use 420x2400x1080
-hw.lcd.density=440
-hw.lcd.height=1920
+hw.lcd.density=420
+hw.lcd.height=2400
 hw.lcd.width=1080
 # Unused
 # hw.sdCard=yes

--- a/emu/templates/avd/MediumPhone.ini
+++ b/emu/templates/avd/MediumPhone.ini
@@ -14,4 +14,4 @@
 
 
 # Basic config used to create an avd for now.
-path=/android-home/Pixel2.avd
+path=/android-home/MediumPhone.avd

--- a/emu/templates/launch-emulator.sh
+++ b/emu/templates/launch-emulator.sh
@@ -108,7 +108,7 @@ install_grpc_certs() {
 clean_up() {
   # Delete any leftovers from hard exits.
   run rm -rf /tmp/*
-  run rm -rf ${ANDROID_AVD_HOME}/Pixel2.avd/*.lock
+  run rm -rf ${ANDROID_AVD_HOME}/MediumPhone.avd/*.lock
 
   # Check for core-dumps, that might be left over
   if ls core* 1>/dev/null 2>&1; then
@@ -144,7 +144,7 @@ initialize_data_part() {
   if  is_mounted /data; then
     run cp -fr /android-home/ /data
     ln -sf /data/android-home ${ANDROID_AVD_HOME}
-    echo "path=${ANDROID_AVD_HOME}/Pixel2.avd" > ${ANDROID_AVD_HOME}/Pixel2.ini
+    echo "path=${ANDROID_AVD_HOME}/MediumPhone.avd" > ${ANDROID_AVD_HOME}/MediumPhone.ini
   else
     ln -sf /android-home ${ANDROID_AVD_HOME}
   fi
@@ -163,7 +163,7 @@ forward_loggers
 # Override config settings that the user forcefully wants to override.
 if [ ! -z "${AVD_CONFIG}" ]; then
   echo "Adding ${AVD_CONFIG} to config.ini"
-  echo "${AVD_CONFIG}" >>"/root/.android/avd/Pixel2.avd/config.ini"
+  echo "${AVD_CONFIG}" >>"/root/.android/avd/MediumPhone.avd/config.ini"
 fi
 
 # Launch internal adb server, needed for our health check.
@@ -175,7 +175,7 @@ socat -d tcp-listen:5555,reuseaddr,fork tcp:127.0.0.1:5557 &
 
 # Basic launcher command, additional flags can be added.
 LAUNCH_CMD=("emulator/emulator")
-LAUNCH_CMD+=("-avd" "Pixel2")
+LAUNCH_CMD+=("-avd" "MediumPhone")
 LAUNCH_CMD+=("-ports" "5556,5557" "-grpc" "8554" "-no-window")
 LAUNCH_CMD+=("-skip-adb-auth" "-no-snapshot-save" "-wipe-data" "-no-boot-anim")
 LAUNCH_CMD+=("-shell-serial" "file:/tmp/android-unknown/kernel.log")


### PR DESCRIPTION
Renames the default AVD from `Pixel2` to `MediumPhone` and updates the device profile to a more modern phone-class form factor.

## Changes
| file | change |
|---|---|
| `emu/templates/avd/Pixel2.avd/` → `MediumPhone.avd/` | rename (git mv) |
| `emu/templates/avd/Pixel2.ini` → `MediumPhone.ini` | rename (git mv) + `path=` line updated |
| `MediumPhone.avd/config.ini` | `AvdId` / `avd.ini.displayname` set to `MediumPhone`; `disk.dataPartition.size` 512MB → 10G; `hw.lcd.density` 440 → 420; `hw.lcd.height` 1920 → 2400; width unchanged at 1080 |
| `emu/containers/emulator_container.py` | two `write_template` calls updated to the new template paths |
| `emu/templates/launch-emulator.sh` | four references updated (lock cleanup, AVD ini bootstrap, `AVD_CONFIG` override path, `-avd` flag) |

Existing built / running containers are unaffected (the AVD config is consumed only at image-build time). New images built with `emu-docker create` boot an AVD called `MediumPhone` with the new dimensions and disk size. `git grep Pixel2` is empty after this change.

## Test plan
- [x] `git grep Pixel2` returns no matches.
- [x] `python -m pytest tests/ --ignore=tests/e2e` — all 35 tests pass.
- [x] End-to-end: rebuilt a fresh API 37 google_apis_playstore ps16k container against emulator dev 36.6.8 from this branch, started cleanly (`sys.boot_completed = 1`). Verified inside the booted device:
  - launch command: `-avd MediumPhone` ✓
  - `wm size` → `Physical size: 1080x2400` ✓
  - `wm density` → `Physical density: 420` ✓
  - `df -h /data/user/0` → `10G total, 8.7G free` ✓
