### PR TITLE
docs: small factual fixes across all .md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Android Emulator Container Scripts
 
 This is a set of minimal scripts to run the emulator in a container for various
-systems such as Docker, for external consumption. The scripts are compatible
-with both Python version 2 and 3.
+systems such as Docker, for external consumption. Requires Python 3.10 or
+newer.
 
 \*Note that this is still an experimental feature and we recommend installing
 this tool in a [python virtual environment](https://docs.python.org/3/tutorial/venv.html).
@@ -19,7 +19,9 @@ following requirements:
 - [Docker](https://docs.docker.com/v17.12/install/) must be installed. Make
   sure you can run it as [non-root
   user](https://docs.docker.com/install/linux/linux-postinstall/)
-- [Docker-compose](https://docs.docker.com/compose/install/) must be installed.
+- [Docker Compose](https://docs.docker.com/compose/install/) must be installed
+  — either the v2 `docker compose` plugin (preferred) or the legacy
+  `docker-compose` v1 command works.
 - KVM must be available. You can get access to KVM by running on "bare metal",
   or on a (virtual) machine that provides nested virtualization. If you are planning to run
   this in the cloud (gce/azure/aws/etc..) you first must make sure you have
@@ -36,7 +38,7 @@ following requirements:
     to enable nested virtualization.
 
 Keep in mind that you will see reduced performance if you are making use of
-nested virtualization. The containers have been tested under Debian and Ubuntu running kernel 5.2.17.
+nested virtualization. The containers have been tested under Debian and Ubuntu.
 
 _NOTE: The images will not run in docker on mac or windows_
 
@@ -240,7 +242,7 @@ a minimal X installation if you are using a cloud instance. For example
 [Xvfb](https://en.wikipedia.org/wiki/Xvfb) can be used. You must build the
 containers by passing in the --gpu flag:
 
-    emu-docker create stable Q --gpu
+    emu-docker create stable U --gpu
 
 You can now launch the emulator with the `run-with-gpu.sh` script:
 
@@ -279,13 +281,13 @@ Where:
 - abi indicates the underlying CPU architecture, which is one of: _x86_, _x86_64_, _a32_, _a64_.
   Note that arm images are not hardware accelerated and might not be fast enough.
 
-For example: _29-playstore-x86:30.1.2_ indicates a playstore enabled system
-image with Q running on 32-bit x86.
+For example: _34-playstore-x64:36.5.11_ indicates a playstore enabled system
+image with U (API 34) running on 64-bit x86_64.
 
-An example invocation for publishing all Q images to google cloud repo could be:
+An example invocation for publishing all U (API 34) images to google cloud repo could be:
 
 ```sh
-    emu-docker -v create --push --repo us.gcr.io/emulator-project/ stable "Q"
+    emu-docker -v create --push --repo us.gcr.io/emulator-project/ stable "U"
 ```
 
 Images that have been pushed to a repository can be launched directly from the repository.
@@ -293,7 +295,7 @@ For example:
 
 ```sh
     docker run --device /dev/kvm --publish 8554:8554/tcp --publish 5555:5555/tcp \
-    us.gcr.io/emulator-project/29-playstore-x86:30.1.2
+    us.gcr.io/emulator-project/34-playstore-x64:36.5.11
 ```
 
 ## Communicating with the emulator in the container

--- a/REGISTRY.MD
+++ b/REGISTRY.MD
@@ -19,9 +19,8 @@ The docker images have the following requirements:
     - AWS provides [bare
       metal](https://aws.amazon.com/about-aws/whats-new/2019/02/introducing-five-new-amazon-ec2-bare-metal-instances/)
       instances that provide access to KVM.
-    - Azure: Follow these
-      [instructions](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/nested-virtualization)
-      to enable nested virtualization.
+    - Azure: pick a [VM size that supports nested virtualization](https://learn.microsoft.com/en-us/azure/virtual-machines/acu)
+      (the `acu` table flags supported families). KVM is then available inside the VM.
     - GCE: Follow these
       [instructions](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances)
       to enable nested virtualization.
@@ -52,7 +51,7 @@ The following environment variables are accepted by the emulator:
 The following ports are available:
 
  - 5555: The [Android Debug Bridge (adb)](https://developer.android.com/studio/command-line/adb) port
- - 8555: The gRPC port. This can be used by android studio and javascript endpoints.
+ - 8554: The gRPC port. This can be used by android studio and javascript endpoints.
 
 An example invocation making the console, adb and the gRPC endpoint available:
 ```sh

--- a/cloud-init/README.MD
+++ b/cloud-init/README.MD
@@ -7,7 +7,7 @@
 You must run a base instance which has KVM and docker available. Details on how to get access to KVM on the various cloud providers can be found here:
 
 - AWS provides [bare metal](https://aws.amazon.com/about-aws/whats-new/2019/02/introducing-five-new-amazon-ec2-bare-metal-instances/) instances that provide access to KVM.
-- Azure: Follow these [instructions](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/nested-virtualization) to enable nested virtualization.
+- Azure: pick a [VM size that supports nested virtualization](https://learn.microsoft.com/en-us/azure/virtual-machines/acu) (the `acu` table flags supported families). KVM is then available inside the VM.
 - GCE: Follow these [instructions](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances) to enable nested virtualization.
 
 _NOTE_ You cannot use GCE's container optimized OS, as it does not make /dev/kvm available. You can follow the steps at the bottom to create you own

--- a/emu/templates/README.md
+++ b/emu/templates/README.md
@@ -1,4 +1,5 @@
 The (sub)directories here contain templates that will be used to create the final docker image.
 The layout should follow the desired layout in the container.
 
-Make sure to update setup.py if you add new directories here.
+Make sure to update `pyproject.toml` (and `MANIFEST.in` if needed) if you add new directories
+here, so the templates ship with the installed package.

--- a/emu/templates/emulator.README.MD
+++ b/emu/templates/emulator.README.MD
@@ -19,9 +19,8 @@ The docker images have the following requirements:
     - AWS provides [bare
       metal](https://aws.amazon.com/about-aws/whats-new/2019/02/introducing-five-new-amazon-ec2-bare-metal-instances/)
       instances that provide access to KVM.
-    - Azure: Follow these
-      [instructions](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/nested-virtualization)
-      to enable nested virtualization.
+    - Azure: pick a [VM size that supports nested virtualization](https://learn.microsoft.com/en-us/azure/virtual-machines/acu)
+      (the `acu` table flags supported families). KVM is then available inside the VM.
     - GCE: Follow these
       [instructions](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances)
       to enable nested virtualization.
@@ -40,7 +39,7 @@ The following ports are available:
 
  - 5554: The emulator [console](https://developer.android.com/studio/run/emulator-console) port.
  - 5555: The [Android Debug Bridge (adb)](https://developer.android.com/studio/command-line/adb) port
- - 8555: The gRPC port. This can be used by android studio and javascript endpoints.
+ - 8554: The gRPC port. This can be used by android studio and javascript endpoints.
 
 An example invocation making the console, adb and the gRPC endpoint available:
 ```sh

--- a/emu/templates/registry.README.MD
+++ b/emu/templates/registry.README.MD
@@ -19,9 +19,8 @@ The docker images have the following requirements:
     - AWS provides [bare
       metal](https://aws.amazon.com/about-aws/whats-new/2019/02/introducing-five-new-amazon-ec2-bare-metal-instances/)
       instances that provide access to KVM.
-    - Azure: Follow these
-      [instructions](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/nested-virtualization)
-      to enable nested virtualization.
+    - Azure: pick a [VM size that supports nested virtualization](https://learn.microsoft.com/en-us/azure/virtual-machines/acu)
+      (the `acu` table flags supported families). KVM is then available inside the VM.
     - GCE: Follow these
       [instructions](https://cloud.google.com/compute/docs/instances/enable-nested-virtualization-vm-instances)
       to enable nested virtualization.
@@ -47,7 +46,7 @@ The following environment variables are accepted by the emulator:
 The following ports are available:
 
  - 5555: The [Android Debug Bridge (adb)](https://developer.android.com/studio/command-line/adb) port
- - 8555: The gRPC port. This can be used by android studio and javascript endpoints.
+ - 8554: The gRPC port. This can be used by android studio and javascript endpoints.
 
 An example invocation making the console, adb and the gRPC endpoint available:
 ```sh

--- a/js/README.md
+++ b/js/README.md
@@ -37,14 +37,14 @@ For fast video over [WebRTC](www.webrtc.org):
     ```
     and make sure that the reported build_id is higher than 5769853
   - Build one from source yourself.
-  - Obtain one from the [build bots](http://go/ab/emu-master-dev). Make sure to get sdk-repo-linux-emulator-XXXX.zip where XXXX is the build number. You can unzip the contents to `$ANDROID_SDK_ROOT`. For example:
+  - Obtain one via `emu-docker list` (which prints download URLs for the publicly published emulator builds) or `emu-docker create <build-id>` to fetch a specific build. Then unzip the contents to `$ANDROID_SDK_ROOT`. For example:
   ```sh
     $ unzip ~/Downloads/sdk-repo-linux-emulator-5775474.zip -d $ANDROID_SDK_ROOT
   ```
 - A valid virtual device to run inside the emulator. Instructions on how to create a virtual device can be found [here](https://developer.android.com/studio/run/managing-avds). Any virtual device can be used.
 - [Node.js](https://nodejs.org/en/) Stable version 10.16.1 LTS or later.
 - A [protobuf](https://developers.google.com/protocol-buffers/) compiler, version 3.6 or higher is supported.
-- [Docker](https://www.docker.com). We will use the container infrastructure for easy deployment. Follow the instructions [here](http://go/installdocker) if you are within Google.
+- [Docker](https://www.docker.com). We will use the container infrastructure for easy deployment. Follow the [install instructions](https://docs.docker.com/get-docker/).
 
 
 # Configure the emulator


### PR DESCRIPTION
Small factual fixes across every Markdown doc with stale or wrong info. No code changes, no structural changes.

## Top-level docs
- **README.md**: drop the obsolete "Python 2 and 3" claim (pyproject requires 3.10+); mention that Docker Compose v2 or v1 both work; drop the stale 2019 kernel-version reference; refresh the "Pushing images to a repository" example from Q / 29-playstore-x86 to U / 34-playstore-x64 with a current emulator version tag.
- **REGISTRY.MD**: fix gRPC port typo (`8555 → 8554`) and update the Azure nested-virt link (same fix already in README.md via #400).

## Templates that generate top-level docs
`REGISTRY.MD` is generated from `emu/templates/registry.README.MD` by `cloud_build.py`; the per-container README from `emu/templates/emulator.README.MD`. Same fixes applied so regeneration doesn't revert.

## Other docs
- **cloud-init/README.MD**: same Azure-link fix.
- **js/README.md**: replace two Google-internal `go/` links (don't resolve outside Google) with public-facing alternatives — `emu-docker list` / `emu-docker create <build-id>` for builds, and `https://docs.docker.com/get-docker/` for Docker.
- **emu/templates/README.md**: `setup.py` → `pyproject.toml` (+ MANIFEST.in).

## Test plan
- [x] `git diff --stat` → 7 files, 25+/25-.
- [x] No code changes; nothing to rebuild or boot.
