### PR TITLE
docker_container: fix docker_image() substring-match misidentification

### DIFF
--- a/emu/containers/docker_container.py
+++ b/emu/containers/docker_container.py
@@ -190,10 +190,16 @@ class DockerContainer:
         Returns:
             {docker.models.images.Image}: A docker image object, or None.
         """
+        target = self.image_name()
         client = self.get_client()
         for img in client.images.list():
             for tag in img.tags:
-                if self.image_name() in tag:
+                # Tags can be "<name>", "<name>:<version>", or
+                # "<repo>/<name>:<version>". Match against the bare name
+                # segment so e.g. "36-google-x64" does not accidentally
+                # pick up "sys-36-google-x64".
+                name_part = tag.split("/")[-1].split(":")[0]
+                if name_part == target:
                     return img
         return None
 

--- a/tests/test_docker_container.py
+++ b/tests/test_docker_container.py
@@ -1,0 +1,120 @@
+# Copyright 2026 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for DockerContainer helpers that don't need a real docker daemon."""
+import unittest.mock as mock
+
+import pytest
+
+from emu.containers.docker_container import DockerContainer
+
+
+class _NamedContainer(DockerContainer):
+    """Minimal DockerContainer subclass for testing the base-class lookups."""
+
+    def __init__(self, name, repo=None):
+        super().__init__(repo)
+        self._name = name
+
+    def image_name(self):
+        return self._name
+
+    def docker_tag(self):
+        return "latest"
+
+    def write(self, dest):  # abstract no-op for the test
+        pass
+
+
+def _img(*tags):
+    """Build a minimal stand-in for a docker.models.images.Image."""
+    m = mock.Mock()
+    m.tags = list(tags)
+    return m
+
+
+@pytest.fixture
+def fake_client(monkeypatch):
+    """Patch docker.from_env so DockerContainer.get_client() returns our stub."""
+    client = mock.Mock()
+    monkeypatch.setattr(
+        "emu.containers.docker_container.docker.from_env", lambda: client
+    )
+    return client
+
+
+# --------------------------------------------------------------------------- #
+# docker_image() — exact-name matching, no substring traps
+# --------------------------------------------------------------------------- #
+
+
+def test_docker_image_matches_bare_name(fake_client):
+    target = _img("36-google-x64:latest")
+    fake_client.images.list.return_value = [target]
+
+    c = _NamedContainer("36-google-x64")
+    assert c.docker_image() is target
+
+
+def test_docker_image_matches_repo_qualified_name(fake_client):
+    target = _img("us-docker.pkg.dev/android-emulator-268719/images/36-google-x64:latest")
+    fake_client.images.list.return_value = [target]
+
+    c = _NamedContainer("36-google-x64")
+    assert c.docker_image() is target
+
+
+def test_docker_image_does_not_match_sys_prefix(fake_client):
+    """The sys-img layer's tag must not satisfy a lookup for the emulator layer."""
+    sys_img = _img("sys-36-google-x64:latest")
+    fake_client.images.list.return_value = [sys_img]
+
+    c = _NamedContainer("36-google-x64")
+    assert c.docker_image() is None
+
+
+def test_docker_image_does_not_match_suffix(fake_client):
+    """A tag with a suffix appended to the target name must not satisfy a bare-name lookup."""
+    suffixed = _img("36-google-x64-foo:latest")
+    fake_client.images.list.return_value = [suffixed]
+
+    c = _NamedContainer("36-google-x64")
+    assert c.docker_image() is None
+
+
+def test_docker_image_picks_exact_among_distractors(fake_client):
+    """With several near-matches present, only the exact one is returned."""
+    sys_img = _img("sys-36-google-x64:latest")
+    ps16k = _img("36-google-x64-ps16k:latest")
+    target = _img("36-google-x64:latest")
+    # exact match is intentionally last in the list to defeat first-hit-wins
+    fake_client.images.list.return_value = [sys_img, ps16k, target]
+
+    c = _NamedContainer("36-google-x64")
+    assert c.docker_image() is target
+
+
+def test_docker_image_returns_none_when_no_images(fake_client):
+    fake_client.images.list.return_value = []
+
+    c = _NamedContainer("36-google-x64")
+    assert c.docker_image() is None
+
+
+def test_docker_image_skips_untagged_image(fake_client):
+    untagged = _img()  # img.tags == []
+    target = _img("36-google-x64:latest")
+    fake_client.images.list.return_value = [untagged, target]
+
+    c = _NamedContainer("36-google-x64")
+    assert c.docker_image() is target


### PR DESCRIPTION
`DockerContainer.docker_image()` looks up the local Docker image for a container by iterating `images.list()` and returning the first whose tag contains `self.image_name()` as a substring. That's too loose: for `image_name() == "36-google-x64"` it accepts `sys-36-google-x64:latest`, `sys-36-google-x64-ps16k:latest`, etc. Whichever appears first in `docker.images.list()` ordering wins, so the result is non-deterministic and frequently wrong.

## Symptoms in practice
- `launch()` picks the wrong image: container starts with `cmd=bash` (the system-image layer's default), exits 0 immediately. Looks like the emulator silently died.
- `create_container()` rebuilds the emulator layer but tags it with the system-image tag (because `full_name()` consults `docker_image()` and gets the wrong hit), overwriting the sys-img layer's tag.
- Both are hard to debug; "rebuild from scratch" works only until the right images repopulate the cache.

## Fix
Change the substring check to an exact-name match against the last path segment of each tag, before the colon:

```diff
-    for img in client.images.list():
-        for tag in img.tags:
-            if self.image_name() in tag:
-                return img
+    target = self.image_name()
+    for img in client.images.list():
+        for tag in img.tags:
+            # Tags can be "<name>", "<name>:<version>", or
+            # "<repo>/<name>:<version>". Match against the bare name
+            # segment so e.g. "36-google-x64" does not accidentally
+            # pick up "sys-36-google-x64".
+            name_part = tag.split("/")[-1].split(":")[0]
+            if name_part == target:
+                return img
```

This correctly handles all three tag shapes the codebase produces.

## Test plan
- [x] Added `tests/test_docker_container.py` with 7 unit tests using a mocked docker client. Cover: exact bare-name match, exact repo-qualified match, sys-prefix is rejected, suffix-appended name is rejected, exact-name wins over near-match distractors regardless of list ordering, empty image list, untagged images.
- [x] All 42 runnable tests under `tests/` pass (35 existing + 7 new).
