### PR TITLE
ci: add GitHub Actions workflow to run pytest on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  pytest:
+    name: pytest (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install package + test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest mock
+
+      - name: Run tests
+        run: pytest tests/ --ignore=tests/e2e -v


### PR DESCRIPTION
Adds `.github/workflows/test.yml` — the first CI on the repository.

## What it does
- Runs `pytest tests/ --ignore=tests/e2e` on every pull request and every push to master.
- Matrix across Python 3.10 / 3.11 / 3.12 / 3.13 (matches the `python = "^3.10"` constraint in `pyproject.toml`).
- `fail-fast: false` so a failure on one Python version doesn't hide failures on the others.
- `actions/setup-python@v5` with `cache: pip` so repeat runs are fast.

## What it does NOT do (intentional scope limits)
- **`black --check`** — the tree is not currently black-formatted (14 files would change). Adding the gate without a separate reformat PR would break master on day one. Reformat is its own discussion.
- **e2e tests** (`tests/e2e/`) — those need a real Docker daemon + KVM, neither available on GitHub-hosted runners. A self-hosted runner with KVM is a follow-up.
- **JS build smoke** (`cd js && npm run build`) — currently passing per #398, but needs a node container in the workflow. Worth its own focused PR.
- **Template render check** (`bash -n` + `shellcheck` against rendered `launch-emulator.sh`) — would catch the kind of bug we hit manually in earlier PRs. Needs a small Python harness; worth its own PR.

## Test plan
- [x] YAML parses (`python -c "import yaml; yaml.safe_load(open(...))"`).
- [x] All unit tests under `tests/` pass locally on Python 3.12.
- [x] `pip install -e .` works against the current `pyproject.toml` (already in daily use via `configure.sh`).
