### PR TITLE
emu-docker create: add --name flag to override generated image name

### DIFF
--- a/emu/containers/emulator_container.py
+++ b/emu/containers/emulator_container.py
@@ -31,11 +31,12 @@ class EmulatorContainer(DockerContainer):
     NO_METRICS_MESSAGE = "No metrics are collected when running this container."
 
     def __init__(
-        self, emulator, system_image_container, repository=None, metrics=False, extra=""
+        self, emulator, system_image_container, repository=None, metrics=False, extra="", name=None
     ):
         self.emulator_zip = AndroidReleaseZip(emulator)
         self.system_image_container = system_image_container
         self.metrics = metrics
+        self.name = name
 
         if type(extra) is list:
             extra = " ".join([f'"{s}"' for s in extra])
@@ -100,6 +101,9 @@ class EmulatorContainer(DockerContainer):
         self.emulator_zip.extract(os.path.join(dest, "emu"))
 
     def image_name(self):
+        if self.name:
+            return self.name
+
         name = "{}-{}-{}".format(
             self.props["ro.build.version.sdk"],
             self.props["qemu.short_tag"],

--- a/emu/emu_docker.py
+++ b/emu/emu_docker.py
@@ -103,7 +103,7 @@ def create_docker_image(args):
             continue
 
         emu_docker = EmulatorContainer(
-            emulator, sys_docker, args.repo, cfg.collect_metrics(), args.extra
+            emulator, sys_docker, args.repo, cfg.collect_metrics(), args.extra, args.name
         )
         emu_docker.build(Path(args.dest) / "emulator")
 
@@ -254,6 +254,9 @@ def main():
     )
     create_parser.add_argument(
         "--sys", action="store_true", help="Process system image layer only."
+    )
+    create_parser.add_argument(
+        "--name", help="Name to give image when pushed.", default=None
     )
     create_parser.set_defaults(func=create_docker_image)
 


### PR DESCRIPTION
## Why

`emu-docker create` auto-generates image names like `36-google-x64-ps16k` from system image properties. Sensible default, but doesn't fit deployments that have their own image-naming convention (e.g., `prod-emu-android16`, or matching an internal registry's path layout).

## Change

Adds a `--name` flag to `emu-docker create` that overrides the auto-generated image name. When unset, behavior is unchanged.

```sh
emu-docker create stable "Q google_apis x86_64" --name my-custom-image-name
```

## Credit

Rebase + extraction of @gregersn's #359, which bundled this with an unrelated `ANDROID_REPOSITORY` env-var feature. Splitting into two PRs (this one + a follow-up for the repository override). Original commit authored 2021-11-04; preserved here as `Author: Greger Stolt Nilsen <greger@fusetools.com>` via cherry-pick onto current master. No code changes from the original — clean cherry-pick, no rebase conflicts.

## Test plan

- [x] All 42 existing unit tests pass (`pytest tests/ --ignore=tests/e2e`) on the cherry-picked commit
- [x] `emu-docker create --help` lists `--name NAME   Name to give image when pushed.`
- [x] `EmulatorContainer.image_name()` returns the override when `self.name` is set
- [x] `name=None` (the default) preserves the existing `<sdk>-<tag>-<cpu>` auto-generation path (covered by existing unit tests)
- [ ] CI from #405 reruns the matrix (Python 3.10/3.11/3.12/3.13)