### PR TITLE
emu_downloads: add ANDROID_REPOSITORY env var to override download base URL

### DIFF
--- a/emu/emu_downloads_menu.py
+++ b/emu/emu_downloads_menu.py
@@ -27,15 +27,17 @@ from consolemenu import SelectionMenu
 from emu.utils import download
 from emu.docker_config import DockerConfig
 
+ANDROID_REPOSITORY = os.environ.get("ANDROID_REPOSITORY", "https://dl.google.com/")
+
 SYSIMG_REPOS = [
-    "https://dl.google.com/android/repository/sys-img/android/sys-img2-5.xml",
-    "https://dl.google.com/android/repository/sys-img/google_apis/sys-img2-5.xml",
-    "https://dl.google.com/android/repository/sys-img/google_apis_playstore/sys-img2-5.xml",
-    "https://dl.google.com/android/repository/sys-img/google_atd/sys-img2-5.xml",
-    "https://dl.google.com/android/repository/sys-img/android-tv/sys-img2-5.xml",
+    "%s/android/repository/sys-img/android/sys-img2-5.xml" % ANDROID_REPOSITORY,
+    "%s/android/repository/sys-img/google_apis/sys-img2-5.xml" % ANDROID_REPOSITORY,
+    "%s/android/repository/sys-img/google_apis_playstore/sys-img2-5.xml" % ANDROID_REPOSITORY,
+    "%s/android/repository/sys-img/google_atd/sys-img2-5.xml" % ANDROID_REPOSITORY,
+    "%s/android/repository/sys-img/android-tv/sys-img2-5.xml" % ANDROID_REPOSITORY,
 ]
 
-EMU_REPOS = ["https://dl.google.com/android/repository/repository2-1.xml"]
+EMU_REPOS = ["%s/android/repository/repository2-1.xml" % ANDROID_REPOSITORY]
 
 CHANNEL_MAPPING = {
     "channel-0": "stable",
@@ -193,7 +195,8 @@ class SysImgInfo(LicensedObject):
         # the <tag> element is labelled — for 16KB variants the path
         # sort is e.g. google_apis_ps16k, served from .../google_apis/.
         url_dir = sort_base or self.tag
-        self.url = "https://dl.google.com/android/repository/sys-img/%s/%s" % (
+        self.url = "%s/android/repository/sys-img/%s/%s" % (
+            ANDROID_REPOSITORY,
             url_dir,
             self.zip,
         )
@@ -252,7 +255,7 @@ class EmuInfo(LicensedObject):
         for archive in archives:
             url = archive.find(".//url").text
             hostos = archive.find("host-os").text
-            self.urls[hostos] = "https://dl.google.com/android/repository/%s" % url
+            self.urls[hostos] = "%s/android/repository/%s" % (ANDROID_REPOSITORY, url)
 
     def download_name(self):
         return "emulator-{}.zip".format(self.version)

--- a/emu/emu_downloads_menu.py
+++ b/emu/emu_downloads_menu.py
@@ -27,7 +27,7 @@ from consolemenu import SelectionMenu
 from emu.utils import download
 from emu.docker_config import DockerConfig
 
-ANDROID_REPOSITORY = os.environ.get("ANDROID_REPOSITORY", "https://dl.google.com/")
+ANDROID_REPOSITORY = os.environ.get("ANDROID_REPOSITORY", "https://dl.google.com").rstrip("/")
 
 SYSIMG_REPOS = [
     "%s/android/repository/sys-img/android/sys-img2-5.xml" % ANDROID_REPOSITORY,

--- a/emu/platform_tools.py
+++ b/emu/platform_tools.py
@@ -11,18 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import zipfile
 from pathlib import Path
 
 from emu.utils import download
 
+ANDROID_REPOSITORY = os.environ.get("ANDROID_REPOSITORY", "https://dl.google.com")
 
 class PlatformTools(object):
     """The platform tools zip file. It will be downloaded on demand."""
 
     # Platform tools, needed to get adb.
     PLATFORM_TOOLS_URL = (
-        "https://dl.google.com/android/repository/platform-tools_r29.0.5-linux.zip"
+        '%s/android/repository/platform-tools_r29.0.5-linux.zip' % ANDROID_REPOSITORY
     )
     PLATFORM_TOOLS_ZIP = "platform-tools-latest-linux.zip"
 

--- a/emu/platform_tools.py
+++ b/emu/platform_tools.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from emu.utils import download
 
-ANDROID_REPOSITORY = os.environ.get("ANDROID_REPOSITORY", "https://dl.google.com")
+ANDROID_REPOSITORY = os.environ.get("ANDROID_REPOSITORY", "https://dl.google.com").rstrip("/")
 
 class PlatformTools(object):
     """The platform tools zip file. It will be downloaded on demand."""


### PR DESCRIPTION
## Why

All system-image and emulator-zip downloads are currently hardcoded to `https://dl.google.com/...`. That breaks for users behind corporate proxies, air-gapped environments, or in regions where Google's CDN is slow/unreachable — most prominently the long-standing #240 ("China available mirror image"). It also makes it hard to test new emulator releases via a staged mirror without forking the script.

## Change

Two commits:

1. **`Add override of download location.`** (cherry-pick of @gregersn's commit from #359, authored 2021-10-11) — introduces an `ANDROID_REPOSITORY` env var, defaulted to `https://dl.google.com`, and uses it as the base for system-image catalogs (`sys-img2-5.xml`), the emulator repo catalog (`repository2-1.xml`), the per-package system-image zip URLs, and the platform-tools download.

2. **`normalize ANDROID_REPOSITORY trailing slash`** (mine) — small follow-up. The two modules disagreed on whether the default had a trailing slash (`https://dl.google.com/` vs `https://dl.google.com`), and combined with format strings starting `/android/...` this produced `https://dl.google.com//android/...` (double slash). Normalized both defaults to no trailing slash and added `.rstrip("/")` so user-supplied bases with a trailing slash also work cleanly.

## Conflict resolution notes

The original cherry-pick had two conflicts against current master, both resolved to keep HEAD's logic and apply the substitution:

- `SYSIMG_REPOS`: kept HEAD's newer `sys-img2-5.xml` filenames (Greger's commit predated the bump and still referenced `sys-img2-1.xml`), wrapped each in `%s/...` with `ANDROID_REPOSITORY`.
- `AndroidReleaseZip.url` construction: kept the `url_dir = sort_base or self.tag` logic (added later for 16KB-page sysimg URL routing — see the `is_16k` work), substituted `ANDROID_REPOSITORY` for the hardcoded base.

## Credit

@gregersn opened the original feature in #359 (along with an unrelated `--name` flag). Splitting into two PRs (#410 for `--name`, this one for `ANDROID_REPOSITORY`) for reviewability. Original authorship preserved on commit 1 via cherry-pick.

## Cross-link

Addresses #240 ("Requesting/Begging for a China available mirror image"). This PR provides the *client-side* override needed to point at any mirror; standing up the actual mirror is out of scope.

## Test plan

- [x] All 42 existing unit tests pass (`pytest tests/ --ignore=tests/e2e`)
- [x] Functional verification of URL construction in three scenarios:
  - No env var: `https://dl.google.com/android/repository/sys-img/android/sys-img2-5.xml`
  - `ANDROID_REPOSITORY=https://my-mirror.example.com`: `https://my-mirror.example.com/android/repository/sys-img/android/sys-img2-5.xml`
  - `ANDROID_REPOSITORY=https://my-mirror.example.com/` (trailing slash): same as above — rstrip prevents double-slash
- [ ] CI from #405 reruns the matrix (Python 3.10/3.11/3.12/3.13)